### PR TITLE
Show committer names in pipeline heading

### DIFF
--- a/src/main/webapp/pipe.js
+++ b/src/main/webapp/pipe.js
@@ -67,7 +67,7 @@ function refreshPipelines(data, divNames, errorDiv, view, showAvatars, showChang
                 var contributors = [];
                 if (pipeline.contributors) {
 		    Q.each(pipeline.contributors, function (index, contributor) {
-			contributors.push(contributor.name);
+			contributors.push(htmlEncode(contributor.name));
 		    });
                 }
 		


### PR DESCRIPTION
This is a quick fix I made for one of my projects at work to make the names of committers appear in the pipeline heading. Before applying this change, the pipeline headings look like this:
![pipeline_without_patch](https://cloud.githubusercontent.com/assets/7282099/2711705/a51fab24-c4d0-11e3-82d2-49d9a8b064fe.png)

With the patch, they look like this, which I consider much more informative:
![pipeline_with_patch](https://cloud.githubusercontent.com/assets/7282099/2711720/cecf9cea-c4d0-11e3-99a7-6a79fc8f0e29.png)
