### PR TITLE
Fixes JENKINS-23282: support delivery pipeline view as the default view

### DIFF
--- a/src/main/java/se/diabol/jenkins/pipeline/DeliveryPipelineView.java
+++ b/src/main/java/se/diabol/jenkins/pipeline/DeliveryPipelineView.java
@@ -222,6 +222,12 @@ public class DeliveryPipelineView extends View {
         }
     }
 
+    // generate the base url for calls to getApi()
+    // support being the default view in Jenkins
+    public String getApiBaseUrl() {
+        return Jenkins.getInstance().getRootUrlFromRequest() + getViewUrl();
+    }
+    
     @Override
     public Api getApi() {
         return new PipelineApi(this);

--- a/src/main/resources/se/diabol/jenkins/pipeline/DeliveryPipelineView/main.jelly
+++ b/src/main/resources/se/diabol/jenkins/pipeline/DeliveryPipelineView/main.jelly
@@ -27,19 +27,11 @@
         </j:default>
     </j:switch>
 
-    <script type="text/javascript">
-        var lastResponse = null;
-        var pipelineContainers = new Array(${it.noOfColumns});
-    </script>
-
     <div id="pipelineerror" class="pipelineerror"/>
 
     <div id="pipeline-message" class="pipeline-message"></div>
 
     <j:forEach begin="1" end="${it.noOfColumns}" indexVar="i">
-        <script type="text/javascript">
-            pipelineContainers[${i-1}] = 'pipelines-${i}';
-        </script>
         <div id="pipelines-${i}" class="left" style="width: ${100/it.noOfColumns}%;"></div>
     </j:forEach>
     <div class="clear"></div>
@@ -49,15 +41,24 @@
     <script type="text/javascript" src="${resURL}/plugin/delivery-pipeline-plugin/jquery.jsPlumb-1.3.16-all-min.js"/>
 
     <script type="text/javascript">
-        var plumb = jsPlumb.getInstance();
+        // TODO: refactor pipe.js to support placing these 
+        //       variables into an anonymous function closure
+        //       to avoid polluting the global namespace
+        var plumb = jsPlumb.getInstance(),
+            lastResponse = null,
+            pipelineContainers = [];
+
+        <j:forEach begin="1" end="${it.noOfColumns}" indexVar="i">
+        pipelineContainers.push('pipelines-${i}');
+        </j:forEach>
 
         Q(window).resize(function () {
             plumb.repaintEverything();
         });
 
+        view.apiBaseUrl = '${it.getApiBaseUrl()}';
 
         updatePipelines(pipelineContainers, "pipelineerror", view, fullscreen, ${it.isShowChanges()}, ${it.updateInterval * 1000});
-
     </script>
 
     <!--<st:include page="legend.jelly"/>-->

--- a/src/main/webapp/pipe.js
+++ b/src/main/webapp/pipe.js
@@ -1,6 +1,6 @@
 function updatePipelines(divNames, errorDiv, view, fullscreen, showChanges, timeout) {
     Q.ajax({
-        url: 'api/json',
+        url: view.apiBaseUrl + 'api/json',
         dataType: 'json',
         async: true,
         cache: false,
@@ -302,7 +302,7 @@ function triggerManual(taskId, downstreamProject, upstreamProject, upstreamBuild
     Q("#manual-" + taskId).hide();
     var formData = {project: downstreamProject, upstream: upstreamProject, buildId: upstreamBuild};
     Q.ajax({
-        url: "api/manualStep",
+        url: view.apiBaseUrl + 'api/manualStep',
         type: "POST",
         data: formData,
         timeout: 20000,


### PR DESCRIPTION
The XHR calls to the delivery pipeline view api do not work
when the view is the default view; this is due to the use of
'api/json' as the api url.  The root level
`http://server/[JenkinsRootUrl]/api/json` URL is reserved
for the JSON API for jobs entities.

This patch forces the XHR calls to use the absolute URL to
the JSON API for the pipeline view, regarldess of
the request URL.

Also includes small reorganization of the embedded Javascript in
main.jelly for readability and eventual use of closures for
best practice variable scoping.
