### PR TITLE
JENKINS-23532 - Suggest removing folder prefix if present when failing to trigger manual step

### DIFF
--- a/src/main/java/se/diabol/jenkins/pipeline/DeliveryPipelineView.java
+++ b/src/main/java/se/diabol/jenkins/pipeline/DeliveryPipelineView.java
@@ -270,12 +270,22 @@ public class DeliveryPipelineView extends View {
                 throw new TriggerException(message);
             }
         } catch (TriggerException e) {
-            LOG.log(Level.WARNING, "Could not trigger manual build " + projectName + " for upstream " +
-                    upstreamName + " id: " + buildId, e);
+            LOG.log(Level.WARNING, triggerExceptionMessage(projectName, upstreamName, buildId), e);
             throw e;
         }
     }
 
+    protected static String triggerExceptionMessage(final String projectName, final String upstreamName, final String buildId) {
+        String message = "Could not trigger manual build " + projectName + " for upstream " + upstreamName + " id: " + buildId;
+        if (projectName.contains("/")) {
+            message += ". Did you mean to specify " + withoutFolderPrefix(projectName) + "?";
+        }
+        return message;
+    }
+
+    protected static String withoutFolderPrefix(final String projectName) {
+        return projectName.substring(projectName.indexOf("/") + 1);
+    }
 
     @Exported
     public List<Component> getPipelines() {

--- a/src/test/java/se/diabol/jenkins/pipeline/DeliveryPipelineViewTest.java
+++ b/src/test/java/se/diabol/jenkins/pipeline/DeliveryPipelineViewTest.java
@@ -438,10 +438,6 @@ public class DeliveryPipelineViewTest {
         assertTrue(names.contains("Project3"));
 
         assertEquals(3, view.getItems().size());
-
-
-
-
     }
 
     @Test
@@ -451,7 +447,32 @@ public class DeliveryPipelineViewTest {
         Api api = view.getApi();
         assertTrue(api instanceof PipelineApi);
     }
-    
+
+    @Test
+    @WithoutJenkins
+    public void withoutFolderPrefixShouldRemoveFolderPrefixIfPresentInProjectName() {
+        final String projectName = "Job1";
+        final String projectNameWithFolderPrefix = "Folder1/" + projectName;
+        assertEquals(projectName, DeliveryPipelineView.withoutFolderPrefix(projectNameWithFolderPrefix));
+    }
+
+    @Test
+    @WithoutJenkins
+    public void withoutFolderPrefixShouldReturnProjectNameIfNoFolderPrefixIsPresent() {
+        final String projectNameWithoutFolderPrefix = "Job2";
+        assertEquals(projectNameWithoutFolderPrefix, DeliveryPipelineView.withoutFolderPrefix(projectNameWithoutFolderPrefix));
+    }
+
+    @Test // JENKINS-23532
+    @WithoutJenkins
+    public void triggerExceptionMessageShouldSuggestRemovingFolderPrefixIfPresent() {
+        final String projectName = "Job3";
+        final String projectNameWithFolderPrefix = "Folder2/" + projectName;
+        final String exceptionMessage = DeliveryPipelineView.triggerExceptionMessage(projectNameWithFolderPrefix, "upstream", "1");
+        assertTrue(exceptionMessage.contains(projectNameWithFolderPrefix));
+        assertTrue(exceptionMessage.contains("Did you mean to specify " + projectName + "?"));
+    }
+
     @Ignore("Ignored due to JenkinsRule 404 for the URL /plugin/jquery-ui/js/jquery-ui-1.8.9.custom.min.js")
     @Test
     public void testDoCreateItem() throws Exception {


### PR DESCRIPTION
If manual trigger fails, error message now suggests removing folder prefix in "Build other projects (manual step)" post-build action if present.
