### PR TITLE
Fix java.lang.StackOverflowError

### DIFF
--- a/src/main/java/se/diabol/jenkins/pipeline/util/BuildUtil.java
+++ b/src/main/java/se/diabol/jenkins/pipeline/util/BuildUtil.java
@@ -64,7 +64,7 @@ public final class BuildUtil {
 
         AbstractBuild upstreamBuild = BuildUtil.getUpstreamBuild(build);
         if (upstreamBuild != null) {
-            if (upstreamBuild.getProject().equals(first)) {
+            if (upstreamBuild.getProject().equals(first) || upstreamBuild.getProject().equals(build.getProject())) {
                 return upstreamBuild;
             } else {
                 return getFirstUpstreamBuild(upstreamBuild, first);


### PR DESCRIPTION
After rebuild (https://wiki.jenkins-ci.org/display/JENKINS/Rebuild+Plugin) in the upstream list may be the same project, so it's causes infinite recursion