### PR TITLE
JENKINS-26746. Fix extreme slowness in setups when there are many Jenkin...

### DIFF
--- a/src/main/java/se/diabol/jenkins/pipeline/util/BuildUtil.java
+++ b/src/main/java/se/diabol/jenkins/pipeline/util/BuildUtil.java
@@ -23,6 +23,7 @@ import hudson.model.AbstractProject;
 import hudson.model.Cause;
 import hudson.model.CauseAction;
 import hudson.util.RunList;
+import jenkins.model.Jenkins;
 
 import java.util.List;
 
@@ -37,7 +38,7 @@ public final class BuildUtil {
             List<Cause.UpstreamCause> causes = Util.filter(action.getCauses(), Cause.UpstreamCause.class);
 
             for (Cause.UpstreamCause upstreamCause : causes) {
-                AbstractProject upstreamProject = ProjectUtil.getProject(upstreamCause.getUpstreamProject());
+                AbstractProject upstreamProject = Jenkins.getInstance().getItemByFullName(upstreamCause.getUpstreamProject(), AbstractProject.class);
                 //Due to https://issues.jenkins-ci.org/browse/JENKINS-14030 when a project has been renamed triggers are not updated correctly
                 if (upstreamProject == null) {
                     return null;


### PR DESCRIPTION
...s folders and projects by using a more standard and optimized means of getting the upstream project for a build. Previously every project in every folder would be traversed to find the upstream project.