### PR TITLE
[JENKINS-27270][JENKINS-27539] Problems with folders

### DIFF
--- a/src/main/java/se/diabol/jenkins/pipeline/util/ProjectUtil.java
+++ b/src/main/java/se/diabol/jenkins/pipeline/util/ProjectUtil.java
@@ -78,7 +78,7 @@ public final class ProjectUtil {
             return projects;
         }
 
-        projects.put(first.getName(), first);
+        projects.put(first.getFullName(), first);
 
         for (AbstractProject p : getDownstreamProjects(first)) {
             projects.putAll(getAllDownstreamProjects(p, projects));
@@ -105,7 +105,7 @@ public final class ProjectUtil {
             Pattern pattern = Pattern.compile(regExp);
             Map<String, AbstractProject> result = new HashMap<String, AbstractProject>();
             for (AbstractProject<?, ?> project : Jenkins.getInstance().getAllItems(AbstractProject.class)) {
-                Matcher matcher = pattern.matcher(project.getName());
+                Matcher matcher = pattern.matcher(project.getFullName());
                 if (matcher.find()) {
                     if (matcher.groupCount() >= 1) {
                         String name = matcher.group(1);

--- a/src/test/java/se/diabol/jenkins/pipeline/util/ProjectUtilTest.java
+++ b/src/test/java/se/diabol/jenkins/pipeline/util/ProjectUtilTest.java
@@ -80,6 +80,23 @@ public class ProjectUtilTest {
     }
 
     @Test
+    public void testGetProjectsInFolders() throws Exception {
+        jenkins.createFolder("folder1");
+        jenkins.createFolder("folder2");
+
+        jenkins.createFreeStyleProject("folder1/project");
+        jenkins.createFreeStyleProject("folder1/otherProject");
+        jenkins.createFreeStyleProject("folder2/project");
+        jenkins.createFreeStyleProject("folder2/otherProject");
+
+        Map<String, AbstractProject> result = ProjectUtil.getProjects("^(project)");
+        assertEquals(0, result.size());
+
+        Map<String, AbstractProject> result2 = ProjectUtil.getProjects("^(.+)/project");
+        assertEquals(2, result2.size());
+    }
+
+    @Test
     public void testGetProjectList() throws Exception {
         jenkins.createFreeStyleProject("p1");
         jenkins.createFreeStyleProject("p2");


### PR DESCRIPTION
This PR solves two problems:

- JENKINS-27270: Regexp should work on lower level jobs as well (i.e. jobs in a folder)
- JENKINS-27539: When jobs with the same basic name exist in different folders, and one of those jobs is used in a pipeline, computation is stopped with a null pointer exception