### PR TITLE
Removed xerces from artifact

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -240,6 +240,12 @@
             <artifactId>promoted-builds</artifactId>
             <version>2.17</version>
             <optional>true</optional>
+            <exclusions>
+                <exclusion>
+                    <groupId>xerces</groupId>
+                    <artifactId>xercesImpl</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
Remove xerces from artifact since it is not needed. Was included from the promoted-builds optional dependency.