### PR TITLE
Fix 405 Method Not Allowed when url contains //

### DIFF
--- a/src/main/webapp/pipe.js
+++ b/src/main/webapp/pipe.js
@@ -383,7 +383,7 @@ function triggerBuild(url, taskId) {
     console.log(url)
 
     Q.ajax({
-        url: rootURL + "/" + url + '/build?delay=0sec',
+        url: rootURL + "/" + url + 'build?delay=0sec',
         type: "GET",
         beforeSend: before,
         timeout: 20000,


### PR DESCRIPTION
AbstractItem.getUrl() always return URL that ends with '/'.