### PR TITLE
changed build trigger from GET to POST

### DIFF
--- a/src/main/webapp/pipe.js
+++ b/src/main/webapp/pipe.js
@@ -384,7 +384,7 @@ function triggerBuild(url, taskId) {
 
     Q.ajax({
         url: rootURL + "/" + url + 'build?delay=0sec',
-        type: "GET",
+        type: "POST",
         beforeSend: before,
         timeout: 20000,
         success: function (data, textStatus, jqXHR) {


### PR DESCRIPTION
The "Start New Pipeline" play button is throwing an error.
![image](https://cloud.githubusercontent.com/assets/3682501/7760679/7bb6e92e-ffe3-11e4-8e69-35cf6399b320.png)

I tracked it down to this line of code
https://github.com/Diabol/delivery-pipeline-plugin/blob/master/src/main/webapp/pipe.js#L380-L387

If I manually try and "GET" the build URL, this error occurs in Jenkins
![image](https://cloud.githubusercontent.com/assets/3682501/7760692/b3b9e16e-ffe3-11e4-8b8b-e69b2bbcfe13.png)

If I "POST" to the /build endpoint with Postman, I get 201 created response
![image](https://cloud.githubusercontent.com/assets/3682501/7760715/ddd1b38c-ffe3-11e4-84c6-2e5d97a7584c.png)


I changed the pipe code from "GET" to "POST"