### PR TITLE
Fixed NPE in unit tests

### DIFF
--- a/src/main/java/se/diabol/jenkins/pipeline/domain/status/SimpleStatus.java
+++ b/src/main/java/se/diabol/jenkins/pipeline/domain/status/SimpleStatus.java
@@ -190,7 +190,10 @@ public class SimpleStatus implements Status {
     private static boolean isBuildPromoted(AbstractBuild build) {
         final List<AbstractPromotionStatusProvider> promotionStatusProviders = SimpleStatus.promotionStatusProviderWrapper.getAllPromotionStatusProviders();
         if(CollectionUtils.isNotEmpty(promotionStatusProviders)) {
-            return promotionStatusProviders.get(0).isBuildPromoted(build);
+            final AbstractPromotionStatusProvider promotionStatusProvider = promotionStatusProviders.get(0);
+            if (promotionStatusProvider != null) {
+                return promotionStatusProvider.isBuildPromoted(build);
+            }
         }
         return false;
     }
@@ -200,7 +203,10 @@ public class SimpleStatus implements Status {
 
         final List<AbstractPromotionStatusProvider> promotionStatusProviders = SimpleStatus.promotionStatusProviderWrapper.getAllPromotionStatusProviders();
         if(CollectionUtils.isNotEmpty(promotionStatusProviders)) {
-            promotionStatusList.addAll(promotionStatusProviders.get(0).getPromotionStatusList(build));
+            final AbstractPromotionStatusProvider promotionStatusProvider = promotionStatusProviders.get(0);
+            if (promotionStatusProvider != null) {
+                promotionStatusList.addAll(promotionStatusProvider.getPromotionStatusList(build));
+            }
         }
         return promotionStatusList;
     }

--- a/src/test/java/se/diabol/jenkins/pipeline/domain/status/SimpleStatusTest.java
+++ b/src/test/java/se/diabol/jenkins/pipeline/domain/status/SimpleStatusTest.java
@@ -26,6 +26,7 @@ import hudson.model.BuildListener;
 import hudson.model.FreeStyleProject;
 import hudson.model.Result;
 import hudson.util.OneShotEvent;
+import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -48,6 +49,13 @@ public class SimpleStatusTest {
 
     @Rule
     public JenkinsRule jenkins = new JenkinsRule();
+
+    private SimpleStatus.PromotionStatusProviderWrapper defaultNotMockedPromotionStatusProviderWrapper = new SimpleStatus.PromotionStatusProviderWrapper();
+
+    @After
+    public void tearDown() {
+        SimpleStatus.setPromotionStatusProviderWrapper(defaultNotMockedPromotionStatusProviderWrapper);
+    }
 
     @Test
     public void testResolveStatusIdle() throws Exception {


### PR DESCRIPTION
Not sure why these test were passing before. 

But now I have added null checks to safeguard against tests which are not well isolated and are not mocking all their dependencies.