### PR TITLE
JENKINS-28837 Successful build should not show solid green background color

### DIFF
--- a/src/main/webapp/pipeline-common.css
+++ b/src/main/webapp/pipeline-common.css
@@ -228,7 +228,6 @@ div.task-progress-running {
 
 .SUCCESS {
     border-left: 6px solid #228b22;
-    background-color: #1bd130;
 }
 
 .UNSTABLE {


### PR DESCRIPTION
Successful build should not show solid green background color in the default (non-fullscreen) view.

Reverted background color set in pipeline-common.css introduced in commit (SHA-1) bba6b4ac2e74048042b2648a58bc45b29c78c87b which seems to fix the problem.