### PR TITLE
Clean up of task

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 Delivery Pipeline Plugin
-========================
+===
 
 [![Build Status](https://travis-ci.org/Diabol/delivery-pipeline-plugin.png)](https://travis-ci.org/Diabol/delivery-pipeline-plugin)
 [![Coverage Status](https://coveralls.io/repos/Diabol/delivery-pipeline-plugin/badge.png?branch=master)](https://coveralls.io/r/Diabol/delivery-pipeline-plugin?branch=master)


### PR DESCRIPTION
Since we are now store a reference to project in Task then it not necessary to lookup the project anymore.
We dont need to pass the ItemGroup.
Needed to change one test since it reloaded Jenkins and then jenkins reloads all project and the test than failed.