### PR TITLE
JENKINS-34084 Allow switching to relative links in the view

### DIFF
--- a/src/main/java/se/diabol/jenkins/pipeline/DeliveryPipelineView.java
+++ b/src/main/java/se/diabol/jenkins/pipeline/DeliveryPipelineView.java
@@ -105,6 +105,7 @@ public class DeliveryPipelineView extends View {
     private boolean showPromotions = false;
     private boolean showTestResults = false;
     private boolean showStaticAnalysisResults = false;
+    private boolean linkRelative = false;
 
     private List<RegExpSpec> regexpFirstJobs;
 
@@ -329,6 +330,15 @@ public class DeliveryPipelineView extends View {
     @Exported
     public boolean isShowStaticAnalysisResults() {
         return showStaticAnalysisResults;
+    }
+
+    @Exported
+    public boolean isLinkRelative() {
+        return linkRelative;
+    }
+
+    public void setLinkRelative(boolean linkRelative) {
+        this.linkRelative = linkRelative;
     }
 
     public void setShowDescription(boolean showDescription)

--- a/src/main/resources/se/diabol/jenkins/pipeline/DeliveryPipelineView/configure-entries.jelly
+++ b/src/main/resources/se/diabol/jenkins/pipeline/DeliveryPipelineView/configure-entries.jelly
@@ -65,6 +65,10 @@
             <f:checkbox/>
         </f:entry>
 
+        <f:entry title="Relative links" field="linkRelative">
+            <f:checkbox/>
+        </f:entry>
+
         <f:entry title="URL for custom CSS file" field="embeddedCss">
             <f:textbox/>
         </f:entry>

--- a/src/main/webapp/pipe.js
+++ b/src/main/webapp/pipe.js
@@ -21,6 +21,14 @@ function updatePipelines(divNames, errorDiv, view, fullscreen, showChanges, time
     });
 }
 
+function getLink(data, link) {
+    if (data.linkRelative) {
+        return link;
+    } else {
+        return rootURL + "/" + link;
+    }
+}
+
 function refreshPipelines(data, divNames, errorDiv, view, showAvatars, showChanges) {
     var lastUpdate = data.lastUpdated,
         cErrorDiv = Q("#" + errorDiv),
@@ -168,7 +176,7 @@ function refreshPipelines(data, divNames, errorDiv, view, showAvatars, showChang
 
                         html.push("<div id=\"" + id + "\" class=\"stage-task " + task.status.type +
                             "\"><div class=\"task-progress " + progressClass + "\" style=\"width: " + progress + "%;\"><div class=\"task-content\">" +
-                            "<div class=\"task-header\"><div class=\"taskname\"><a href=\"" + rootURL + "/" + task.link + "\">" + htmlEncode(task.name) + "</a></div>");
+                            "<div class=\"task-header\"><div class=\"taskname\"><a href=\"" + getLink(data, task.link) + "\">" + htmlEncode(task.name) + "</a></div>");
                         if (data.allowManualTriggers && task.manual && task.manualStep.enabled && task.manualStep.permission) {
                             html.push('<div class="task-manual" id="manual-' + id + '" title="Trigger manual build" onclick="triggerManual(\'' + id + '\', \'' + task.id + '\', \'' + task.manualStep.upstreamProject + '\', \'' + task.manualStep.upstreamId + '\');">');
                             html.push("</div>");
@@ -285,7 +293,7 @@ function generateTestInfo(data, task) {
         var html = ["<div class='infoPanelOuter'>"];
         Q.each(task.testResults, function(i, analysis) {
             html.push("<div class='infoPanel'><div class='infoPanelInner'>");
-                html.push("<a href=" + rootURL + "/" + analysis.url + ">" + analysis.name + "</a>");
+                html.push("<a href=" + getLink(data,analysis.url) + ">" + analysis.name + "</a>");
                 html.push("<table id='priority.summary' class='pane'>");
                 html.push("<tbody>");
                     html.push("<tr>");
@@ -314,7 +322,7 @@ function generateStaticAnalysisInfo(data, task) {
         var html = ["<div class='infoPanelOuter'>"];
         Q.each(task.staticAnalysisResults, function(i, analysis) {
             html.push("<div class='infoPanel'><div class='infoPanelInner'>");
-                html.push("<a href=" + rootURL + "/" + analysis.url + ">" + analysis.name + "</a>");
+                html.push("<a href=" + getLink(data,analysis.url) + ">" + analysis.name + "</a>");
                 html.push("<table id='priority.summary' class='pane'>");
                 html.push("<tbody>");
                     html.push("<tr>");
@@ -344,7 +352,7 @@ function generatePromotionsInfo(data, task) {
         Q.each(task.status.promotions, function(i, promo) {
             html.push("<div class='infoPanel'><div class='infoPanelInner'>");
             html.push("<img class='promo-icon' height='16' width='16' src='" + rootURL + promo.icon + "'/>");
-            html.push("<span class='promo-name'><a href='" + rootURL + "/" + task.link + "promotion'>" + htmlEncode(promo.name) + "</a></span><br/>");
+            html.push("<span class='promo-name'><a href='" + getLink(data,task.link) + "promotion'>" + htmlEncode(promo.name) + "</a></span><br/>");
             if (promo.user != 'anonymous') {
                 html.push("<span class='promo-user'>" + promo.user + "</span>");
             }

--- a/src/test/java/se/diabol/jenkins/pipeline/DeliveryPipelineViewTest.java
+++ b/src/test/java/se/diabol/jenkins/pipeline/DeliveryPipelineViewTest.java
@@ -202,6 +202,7 @@ public class DeliveryPipelineViewTest {
         assertFalse(view.isShowPromotions());
         assertFalse(view.isShowTestResults());
         assertFalse(view.isShowStaticAnalysisResults());
+        assertFalse(view.isLinkRelative());
     }
 
     @Test
@@ -235,6 +236,8 @@ public class DeliveryPipelineViewTest {
         assertTrue(view.isShowTestResults());
         view.setShowStaticAnalysisResults(true);
         assertTrue(view.isShowStaticAnalysisResults());
+        view.setLinkRelative(true);
+        assertTrue(view.isLinkRelative());
     }
 
     @Test


### PR DESCRIPTION
I added an option to use relative links where possible (except the triggering builds) for easier navigation. Personally, I always struggle to get back to the delivery view after investigating a build/job