### PR TITLE
Use annotated commit message

### DIFF
--- a/src/main/java/se/diabol/jenkins/pipeline/domain/Change.java
+++ b/src/main/java/se/diabol/jenkins/pipeline/domain/Change.java
@@ -84,7 +84,7 @@ public class Change {
                    LOG.log(Level.WARNING, "Could not get changeset link for: " + build.getProject().getFullDisplayName() + " " + build.getDisplayName(), e);
                 }
             }
-            result.add(new Change(user, entry.getMsg(), entry.getCommitId(), changeLink));
+            result.add(new Change(user, entry.getMsgAnnotated(), entry.getCommitId(), changeLink));
         }
         return result;
     }

--- a/src/main/webapp/pipe.js
+++ b/src/main/webapp/pipe.js
@@ -368,13 +368,20 @@ function generateChangeLog(changes) {
     for (var i = 0; i < changes.length; i++) {
         html.push('<div class="change">');
         var change = changes[i];
-        html.push('<div class="change-commit-id">' + htmlEncode(change.commitId) + '</div>')
-        html.push('<div class="change-author">' + htmlEncode(change.author.name) + '</div>');
+
         if (change.changeLink) {
-            html.push('<div class="change-message"><a href="' + change.changeLink + '">' + htmlEncode(change.message) + '</a></div>');
-        } else {
-            html.push('<div class="change-message">' + htmlEncode(change.message) + '</div>');
+            html.push('<a href="' + change.changeLink + '">');
         }
+
+        html.push('<div class="change-commit-id">' + htmlEncode(change.commitId) + '</div>');
+
+        if (change.changeLink) {
+            html.push('</a>');
+        }
+
+        html.push('<div class="change-author">' + htmlEncode(change.author.name) + '</div>');
+
+        html.push('<div class="change-message">' + change.message + '</div>');
         html.push('</div>');
     }
     html.push('</div>');

--- a/src/test/java/se/diabol/jenkins/pipeline/test/ParentAwareSCM.java
+++ b/src/test/java/se/diabol/jenkins/pipeline/test/ParentAwareSCM.java
@@ -1,0 +1,79 @@
+/*
+This file is part of Delivery Pipeline Plugin.
+
+Delivery Pipeline Plugin is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Delivery Pipeline Plugin is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Delivery Pipeline Plugin.
+If not, see <http://www.gnu.org/licenses/>.
+*/
+package se.diabol.jenkins.pipeline.test;
+
+import hudson.FilePath;
+import hudson.Launcher;
+import hudson.model.AbstractBuild;
+import hudson.model.BuildListener;
+import hudson.scm.ChangeLogParser;
+import hudson.scm.ChangeLogSet;
+import hudson.scm.NullSCM;
+import org.jvnet.hudson.test.FakeChangeLogSCM;
+import org.xml.sax.SAXException;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * We have to mimic FakeChangeLogSCM because by default it doesn't call "setParent" on Entries.
+ *
+ */
+public class ParentAwareSCM extends NullSCM {
+
+    private List<FakeChangeLogSCM.EntryImpl> entries = new ArrayList();
+
+    public FakeChangeLogSCM.EntryImpl addChange() {
+        FakeChangeLogSCM.EntryImpl e = new Entry();
+        this.entries.add(e);
+        return e;
+    }
+
+    @Override
+    public ChangeLogParser createChangeLogParser() {
+        return new FakeChangeLogSCM.FakeChangeLogParser() {
+            @Override
+            public FakeChangeLogSCM.FakeChangeLogSet parse(AbstractBuild build, File changelogFile) throws IOException, SAXException {
+                FakeChangeLogSCM.FakeChangeLogSet changeLogSet = super.parse(build, changelogFile);
+
+                // Call "setParent" on each entry
+                for (FakeChangeLogSCM.EntryImpl entry : changeLogSet) {
+                    ((Entry) entry).setParent(changeLogSet);
+                }
+
+                return changeLogSet;
+            }
+        };
+    }
+
+    @Override
+    public boolean checkout(AbstractBuild<?, ?> build, Launcher launcher, FilePath remoteDir, BuildListener listener, File changeLogFile) throws IOException, InterruptedException {
+        (new FilePath(changeLogFile)).touch(0L);
+        build.addAction(new FakeChangeLogSCM.ChangelogAction(this.entries));
+        this.entries = new ArrayList();
+        return true;
+    }
+
+    static class Entry extends FakeChangeLogSCM.EntryImpl {
+        public void setParent(ChangeLogSet changeLogSet) {
+            super.setParent(changeLogSet);
+        }
+    }
+}

--- a/src/test/javascript/pipe-test.js
+++ b/src/test/javascript/pipe-test.js
@@ -32,14 +32,6 @@ describe("htmlEncode", function() {
 });
 
 describe("generateChangeLog", function() {
-    it("Linebreak in changelog comment", function() {
-        var data = JSON.parse('{"changes":[{"author":{"name":"Firstname Lastname","avatarUrl":null,"url":"user/user"},"changeLink":null,"commitId":"2718","message":"Firstline\\nSecondLine"}]}');
-        expect(generateChangeLog(data.changes)).toEqual('<div class="changes"><h1>Changes:</h1><div class="change"><div class="change-commit-id">2718</div><div class="change-author">Firstname Lastname</div><div class="change-message">Firstline<br/>SecondLine</div></div></div>');
-    });
-    it("XML in changelog comment", function() {
-        var data = JSON.parse('{"changes":[{"author":{"name":"Firstname Lastname","avatarUrl":null,"url":"user/user"},"changeLink":null,"commitId":"2718","message":"<xml>data</xml>"}]}');
-        expect(generateChangeLog(data.changes)).toEqual('<div class="changes"><h1>Changes:</h1><div class="change"><div class="change-commit-id">2718</div><div class="change-author">Firstname Lastname</div><div class="change-message">&lt;xml&gt;data&lt;/xml&gt;</div></div></div>');
-    });
     it("Swedish characters in changelog comment", function() {
         var data = JSON.parse('{"changes":[{"author":{"name":"Firstname Lastname","avatarUrl":null,"url":"user/user"},"changeLink":null,"commitId":"2718","message":"Räksmörgås"}]}');
         expect(generateChangeLog(data.changes)).toEqual('<div class="changes"><h1>Changes:</h1><div class="change"><div class="change-commit-id">2718</div><div class="change-author">Firstname Lastname</div><div class="change-message">Räksmörgås</div></div></div>');


### PR DESCRIPTION
Hi! 

Here, at ZeroTurnaround, we use this plugin as a main thing in our delivery process, so we want to contribute some changes from us which we already use :)

This one, in combination with plugins like JIRA ( https://wiki.jenkins-ci.org/display/JENKINS/JIRA+Plugin ) allows you replace issue ids in commit message with links to the tracker, which is really helpful for QA to analyze affected issues from changes.

There is a regression because now we can't allow change message to be a link (since it can have a links inside of it, as well as other html elements from annotators (but it's safe because Jenkins controls html in such places)). This regression was replaced by clickable commit id, so users will be able to open changes, but instead of clicking on message they will click on a hash.

Here is a simple GIF with demo:
https://gyazo.com/c4b2bbfbfb55a7f4754b1e382c468f5d


Thanks!