### PR TITLE
JENKINS-31670 - Add ability to aggregate changes between stages

### DIFF
--- a/src/main/java/se/diabol/jenkins/pipeline/DeliveryPipelineView.java
+++ b/src/main/java/se/diabol/jenkins/pipeline/DeliveryPipelineView.java
@@ -105,6 +105,8 @@ public class DeliveryPipelineView extends View {
     private boolean showPromotions = false;
     private boolean showTestResults = false;
     private boolean showStaticAnalysisResults = false;
+    private boolean showAggregatedChanges = false;
+    private String aggregatedChangesGroupingPattern = null;
 
     private List<RegExpSpec> regexpFirstJobs;
 
@@ -348,6 +350,24 @@ public class DeliveryPipelineView extends View {
         this.showStaticAnalysisResults = showStaticAnalysisResults;
     }
 
+    @Exported
+    public boolean isShowAggregatedChanges() {
+        return showAggregatedChanges;
+    }
+
+    public void setShowAggregatedChanges(boolean showAggregatedChanges) {
+        this.showAggregatedChanges = showAggregatedChanges;
+    }
+
+    @Exported
+    public String getAggregatedChangesGroupingPattern() {
+        return aggregatedChangesGroupingPattern;
+    }
+
+    public void setAggregatedChangesGroupingPattern(String aggregatedChangesGroupingPattern) {
+        this.aggregatedChangesGroupingPattern = aggregatedChangesGroupingPattern;
+    }
+
     @JavaScriptMethod
     public void triggerManual(String projectName, String upstreamName, String buildId) throws TriggerException, AuthenticationException {
         try {
@@ -446,7 +466,7 @@ public class DeliveryPipelineView extends View {
         Pipeline pipeline = Pipeline.extractPipeline(name, firstJob, lastJob);
         List<Pipeline> pipelines = new ArrayList<Pipeline>();
         if (showAggregatedPipeline) {
-            pipelines.add(pipeline.createPipelineAggregated(getOwnerItemGroup()));
+            pipelines.add(pipeline.createPipelineAggregated(getOwnerItemGroup(), showAggregatedChanges));
         }
         pipelines.addAll(pipeline.createPipelineLatest(noOfPipelines, getOwnerItemGroup()));
         return new Component(name, firstJob.getName(), firstJob.getUrl(), firstJob.isParameterized(), pipelines);

--- a/src/main/java/se/diabol/jenkins/pipeline/domain/Change.java
+++ b/src/main/java/se/diabol/jenkins/pipeline/domain/Change.java
@@ -67,6 +67,21 @@ public class Change {
         return changeLink;
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        Change change = (Change) o;
+
+        return commitId.equals(change.commitId);
+    }
+
+    @Override
+    public int hashCode() {
+        return commitId.hashCode();
+    }
+
     public static List<Change> getChanges(AbstractBuild<?, ?> build) {
         RepositoryBrowser repositoryBrowser = build.getProject().getScm().getBrowser();
         List<Change> result = new ArrayList<Change>();

--- a/src/main/java/se/diabol/jenkins/pipeline/domain/Pipeline.java
+++ b/src/main/java/se/diabol/jenkins/pipeline/domain/Pipeline.java
@@ -23,6 +23,7 @@ import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
 import hudson.model.ItemGroup;
 
+import hudson.model.Result;
 import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.export.ExportedBean;
 
@@ -38,6 +39,7 @@ import java.util.Set;
 
 import static com.google.common.base.Objects.toStringHelper;
 import static com.google.common.collect.Lists.newArrayList;
+import static com.google.common.collect.Sets.newHashSet;
 
 @ExportedBean(defaultVisibility = AbstractItem.VISIBILITY)
 public class Pipeline extends AbstractItem {
@@ -195,10 +197,34 @@ public class Pipeline extends AbstractItem {
     }
 
     public Pipeline createPipelineAggregated(ItemGroup context) {
+        return createPipelineAggregated(context, false);
+    }
+
+    public Pipeline createPipelineAggregated(ItemGroup context, boolean showAggregatedChanges) {
         List<Stage> pipelineStages = new ArrayList<Stage>();
         for (Stage stage : getStages()) {
             pipelineStages.add(stage.createAggregatedStage(context, firstProject));
         }
+
+        if (showAggregatedChanges) {
+            // We use size() - 1 because last stage's changelog can't be calculated against next stage (no such)
+            for (int i = 0; i < pipelineStages.size() - 1; i++) {
+                Stage stage = pipelineStages.get(i);
+                Stage nextStage = pipelineStages.get(i + 1);
+
+                final AbstractBuild nextBuild = nextStage.getHighestBuild(firstProject, context, Result.SUCCESS);
+
+                Set<Change> changes = newHashSet();
+
+                AbstractBuild build = stage.getHighestBuild(firstProject, context, Result.SUCCESS);
+                for (; build != null && build != nextBuild; build = build.getPreviousBuild()) {
+                    changes.addAll(Change.getChanges(build));
+                }
+
+                stage.setChanges(changes);
+            }
+        }
+
         return new Pipeline(getName(), firstProject, lastProject, null, null, null, null, pipelineStages, true);
     }
 

--- a/src/main/resources/se/diabol/jenkins/pipeline/DeliveryPipelineView/configure-entries.jelly
+++ b/src/main/resources/se/diabol/jenkins/pipeline/DeliveryPipelineView/configure-entries.jelly
@@ -11,6 +11,14 @@
             <f:checkbox/>
         </f:entry>
 
+        <f:entry title="Display aggregated changelog in aggregated view" field="showAggregatedChanges">
+            <f:checkbox/>
+        </f:entry>
+
+        <f:entry title="Group aggregated changelog by regular expression" field="aggregatedChangesGroupingPattern">
+            <f:textbox/>
+        </f:entry>
+
         <f:entry title="Number of columns" field="noOfColumns">
             <f:select/>
         </f:entry>

--- a/src/main/resources/se/diabol/jenkins/pipeline/DeliveryPipelineView/help-aggregatedChangesGroupingPattern.html
+++ b/src/main/resources/se/diabol/jenkins/pipeline/DeliveryPipelineView/help-aggregatedChangesGroupingPattern.html
@@ -1,0 +1,3 @@
+<div>
+    (Optional) Group changelog by regex pattern (i.e. "JENKINS\-[0-9]+").
+</div>

--- a/src/main/resources/se/diabol/jenkins/pipeline/DeliveryPipelineView/help-showAggregatedChanges.html
+++ b/src/main/resources/se/diabol/jenkins/pipeline/DeliveryPipelineView/help-showAggregatedChanges.html
@@ -1,0 +1,3 @@
+<div>
+    Show an aggregated changelog between different stages.
+</div>

--- a/src/main/resources/se/diabol/jenkins/pipeline/DeliveryPipelineView/main.jelly
+++ b/src/main/resources/se/diabol/jenkins/pipeline/DeliveryPipelineView/main.jelly
@@ -74,6 +74,10 @@
         view.viewUrl = '${it.getViewUrl()}';
 
         updatePipelines(pipelineContainers, "pipelineerror", view, fullscreen, ${it.isShowChanges()},
+        <j:choose>
+            <j:when test="it.getAggregatedChangesGroupingPattern()">/${it.getAggregatedChangesGroupingPattern()}/g</j:when>
+            <j:otherwise>null</j:otherwise>
+        </j:choose>,
         ${it.updateInterval * 1000});
     </script>
     </div>

--- a/src/main/webapp/pipeline-common.css
+++ b/src/main/webapp/pipeline-common.css
@@ -318,6 +318,32 @@ div.infoPanelOuter {
     border: 1px solid lightgray;
     background-color: #FAF8F8;
 }
+
+div.aggregatedChangesPanel {
+    display:block;
+    max-width:300px;
+    padding-left:2px;
+    padding-right:2px;
+    margin-top:-2px;
+    border-top:none;
+}
+
+div.aggregatedChangesPanelInner {
+    padding:8px 4px;
+    overflow: hidden;
+    border: 0;
+}
+
+div.aggregatedChangesPanelOuter {
+    margin: 8px;
+    border: 1px solid lightgray;
+    background-color: #FAF8F8;
+}
+
+div.aggregatedChangesPanelInner > ul {
+    padding-left: 1.2em;
+}
+
 .MANUALTASK {
     border-right: 6px solid #FFE4E1;
 }


### PR DESCRIPTION
Hi,

One more contribution from ZeroTurnaround :)
First, demo: 
![Demo](https://i.gyazo.com/14a750cbcbec35ab0029a8b677b0a462.gif)
https://gyazo.com/14a750cbcbec35ab0029a8b677b0a462

Background:
Our QA was always asking about "changes in that build", "which JIRA tasks were affected", etc...
This contribution allows you to track *aggregated* changes between stages (check demo). Why aggregated? Because it aggregates changes in all builds between stages, not only latest, so, if one build was rejected by QA, new build will contain changes from both new and rejected ones.

We're using this functionality for more then 1 month and it's stable (from our perspective) 

https://issues.jenkins-ci.org/browse/JENKINS-31670