### PR TITLE
ability to exclude jobs from pipeline view using excludeJobsRegex

### DIFF
--- a/src/main/java/se/diabol/jenkins/pipeline/DeliveryPipelineView.java
+++ b/src/main/java/se/diabol/jenkins/pipeline/DeliveryPipelineView.java
@@ -413,7 +413,9 @@ public class DeliveryPipelineView extends View {
                     AbstractProject firstJob = ProjectUtil.getProject(componentSpec.getFirstJob(), getOwnerItemGroup());
                     AbstractProject lastJob = ProjectUtil.getProject(componentSpec.getLastJob(), getOwnerItemGroup());
                     if (firstJob != null) {
-                        components.add(getComponent(componentSpec.getName(), firstJob, lastJob, showAggregatedPipeline));
+                        String name = componentSpec.getName();
+                        String excludeJobsRegex = componentSpec.getExcludeJobsRegex();
+                        components.add(getComponent(name, firstJob, lastJob, excludeJobsRegex, showAggregatedPipeline));
                     } else {
                         throw new PipelineException("Could not find project: " + componentSpec.getFirstJob());
                     }
@@ -423,7 +425,7 @@ public class DeliveryPipelineView extends View {
                 for (RegExpSpec regexp : regexpFirstJobs) {
                     Map<String, AbstractProject> matches = ProjectUtil.getProjects(regexp.getRegexp());
                     for (Map.Entry<String, AbstractProject> entry : matches.entrySet()) {
-                        components.add(getComponent(entry.getKey(), entry.getValue(), null, showAggregatedPipeline));
+                        components.add(getComponent(entry.getKey(), entry.getValue(), null, null, showAggregatedPipeline));
                     }
                 }
             }
@@ -442,8 +444,8 @@ public class DeliveryPipelineView extends View {
         }
     }
 
-    private Component getComponent(String name, AbstractProject firstJob, AbstractProject lastJob, boolean showAggregatedPipeline) throws PipelineException {
-        Pipeline pipeline = Pipeline.extractPipeline(name, firstJob, lastJob);
+    private Component getComponent(String name, AbstractProject firstJob, AbstractProject lastJob, String excludeJobsRegex, boolean showAggregatedPipeline) throws PipelineException {
+        Pipeline pipeline = Pipeline.extractPipeline(name, firstJob, lastJob, excludeJobsRegex);
         List<Pipeline> pipelines = new ArrayList<Pipeline>();
         if (showAggregatedPipeline) {
             pipelines.add(pipeline.createPipelineAggregated(getOwnerItemGroup()));
@@ -573,12 +575,14 @@ public class DeliveryPipelineView extends View {
         private String name;
         private String firstJob;
         private String lastJob;
+        private String excludeJobsRegex;
 
         @DataBoundConstructor
-        public ComponentSpec(String name, String firstJob, String lastJob) {
+        public ComponentSpec(String name, String firstJob, String lastJob, String excludeJobsRegex) {
             this.name = name;
             this.firstJob = firstJob;
             this.lastJob = lastJob;
+            this.excludeJobsRegex = excludeJobsRegex;
         }
 
         public String getName() {
@@ -599,6 +603,14 @@ public class DeliveryPipelineView extends View {
 
         public void setLastJob(String lastJob) {
             this.lastJob = lastJob;
+        }
+
+        public String getExcludeJobsRegex() {
+            return excludeJobsRegex;
+        }
+
+        public void setExcludeJobsRegex(String excludeJobsRegex) {
+            this.excludeJobsRegex = excludeJobsRegex;
         }
 
         @Extension

--- a/src/main/java/se/diabol/jenkins/pipeline/DeliveryPipelineView.java
+++ b/src/main/java/se/diabol/jenkins/pipeline/DeliveryPipelineView.java
@@ -609,10 +609,6 @@ public class DeliveryPipelineView extends View {
             return excludeJobsRegex;
         }
 
-        public void setExcludeJobsRegex(String excludeJobsRegex) {
-            this.excludeJobsRegex = excludeJobsRegex;
-        }
-
         @Extension
         public static class DescriptorImpl extends Descriptor<ComponentSpec> {
 

--- a/src/main/java/se/diabol/jenkins/pipeline/domain/Pipeline.java
+++ b/src/main/java/se/diabol/jenkins/pipeline/domain/Pipeline.java
@@ -186,12 +186,14 @@ public class Pipeline extends AbstractItem {
     /**
      * Created a pipeline prototype for the supplied first project
      */
-    public static Pipeline extractPipeline(String name, AbstractProject<?, ?> firstProject, AbstractProject<?, ?> lastProject) throws PipelineException {
-        return new Pipeline(name, firstProject, lastProject, newArrayList(Stage.extractStages(firstProject, lastProject)));
+    public static Pipeline extractPipeline(String name, AbstractProject<?, ?> firstProject, AbstractProject<?, ?> lastProject, String excludeJobsRegex) throws PipelineException {
+        List<Stage> stages = Stage.extractStages(firstProject, lastProject, excludeJobsRegex);
+        return new Pipeline(name, firstProject, lastProject, newArrayList(stages));
     }
 
     public static Pipeline extractPipeline(String name, AbstractProject<?, ?> firstProject) throws PipelineException {
-        return new Pipeline(name, firstProject, null, newArrayList(Stage.extractStages(firstProject, null)));
+        List<Stage> stages = Stage.extractStages(firstProject, null, null);
+        return new Pipeline(name, firstProject, null, newArrayList(stages));
     }
 
     public Pipeline createPipelineAggregated(ItemGroup context) {

--- a/src/main/java/se/diabol/jenkins/pipeline/domain/Stage.java
+++ b/src/main/java/se/diabol/jenkins/pipeline/domain/Stage.java
@@ -47,6 +47,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 import static com.google.common.base.Objects.toStringHelper;
 import static com.google.common.base.Strings.isNullOrEmpty;
@@ -57,6 +58,9 @@ import static java.util.Collections.singleton;
 
 @ExportedBean(defaultVisibility = AbstractItem.VISIBILITY)
 public class Stage extends AbstractItem {
+
+    private static final Pattern MATCH_NONE_PATTERN = Pattern.compile(".^");
+
     private List<Task> tasks;
 
     private String version;
@@ -155,27 +159,32 @@ public class Stage extends AbstractItem {
         return new Stage(name, tasks);
     }
 
-    public static List<Stage> extractStages(AbstractProject firstProject, AbstractProject lastProject) throws PipelineException {
+    public static List<Stage> extractStages(AbstractProject firstProject, AbstractProject lastProject, String excludeJobsRegex) throws PipelineException {
         Map<String, Stage> stages = newLinkedHashMap();
+        Pattern excludeJobsPattern = excludeJobsRegex == null ? MATCH_NONE_PATTERN : Pattern.compile(excludeJobsRegex);
         for (AbstractProject project : ProjectUtil.getAllDownstreamProjects(firstProject, lastProject).values()) {
-            Task task = Task.getPrototypeTask(project, project.getFullName().equals(firstProject.getFullName()));
-            /* if current project is last we need clean downStreamTasks*/
-            if (lastProject != null && project.getFullName().equals(lastProject.getFullName())) {
-                task.getDownstreamTasks().clear();
-            }
+            String projectName = project.getName();
+            if (!excludeJobsPattern.matcher(projectName).matches()) {
+                boolean isInitialTask = project.getFullName().equals(firstProject.getFullName());
+                Task task = Task.getPrototypeTask(project, isInitialTask, excludeJobsPattern);
+                /* if current project is last we need clean downStreamTasks*/
+                if (lastProject != null && project.getFullName().equals(lastProject.getFullName())) {
+                    task.getDownstreamTasks().clear();
+                }
 
-            PipelineProperty property = (PipelineProperty) project.getProperty(PipelineProperty.class);
-            if (property == null && project.getParent() instanceof AbstractProject) {
-                property = (PipelineProperty) ((AbstractProject) project.getParent()).getProperty(PipelineProperty.class);
+                PipelineProperty property = (PipelineProperty) project.getProperty(PipelineProperty.class);
+                if (property == null && project.getParent() instanceof AbstractProject) {
+                    property = (PipelineProperty) ((AbstractProject) project.getParent()).getProperty(PipelineProperty.class);
+                }
+                String stageName = property != null && !isNullOrEmpty(property.getStageName())
+                        ? property.getStageName() : project.getDisplayName();
+                Stage stage = stages.get(stageName);
+                if (stage == null) {
+                    stage = Stage.getPrototypeStage(stageName, Collections.<Task>emptyList());
+                }
+                stages.put(stageName,
+                        Stage.getPrototypeStage(stage.getName(), newArrayList(concat(stage.getTasks(), singleton(task)))));
             }
-            String stageName = property != null && !isNullOrEmpty(property.getStageName())
-                    ? property.getStageName() : project.getDisplayName();
-            Stage stage = stages.get(stageName);
-            if (stage == null) {
-                stage = Stage.getPrototypeStage(stageName, Collections.<Task>emptyList());
-            }
-            stages.put(stageName,
-                    Stage.getPrototypeStage(stage.getName(), newArrayList(concat(stage.getTasks(), singleton(task)))));
         }
         Collection<Stage> stagesResult = stages.values();
 

--- a/src/main/java/se/diabol/jenkins/pipeline/domain/task/Task.java
+++ b/src/main/java/se/diabol/jenkins/pipeline/domain/task/Task.java
@@ -38,6 +38,7 @@ import se.diabol.jenkins.pipeline.util.ProjectUtil;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Pattern;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static se.diabol.jenkins.pipeline.domain.status.StatusFactory.disabled;
@@ -159,7 +160,7 @@ public class Task extends AbstractItem {
         return initial;
     }
 
-    public static Task getPrototypeTask(AbstractProject project, boolean initial) {
+    public static Task getPrototypeTask(AbstractProject project, boolean initial, Pattern excludeJobsPattern) {
         PipelineProperty property = (PipelineProperty) project.getProperty(PipelineProperty.class);
         String taskName = property != null && !isNullOrEmpty(property.getTaskName())
                 ? property.getTaskName() : project.getDisplayName();
@@ -177,7 +178,10 @@ public class Task extends AbstractItem {
         List<AbstractProject> downStreams = ProjectUtil.getDownstreamProjects(project);
         List<String> downStreamTasks = new ArrayList<String>();
         for (AbstractProject downstreamProject : downStreams) {
-            downStreamTasks.add(downstreamProject.getRelativeNameFrom(Jenkins.getInstance()));
+            String downstreamTaskName = downstreamProject.getRelativeNameFrom(Jenkins.getInstance());
+            if (!excludeJobsPattern.matcher(downstreamTaskName).matches()) {
+                downStreamTasks.add(downstreamTaskName);
+            }
         }
         return new Task(project, project.getRelativeNameFrom(Jenkins.getInstance()), taskName, status,
                 project.getUrl(), ManualStep.resolveManualStep(project), downStreamTasks, initial, descriptionTemplate);

--- a/src/main/resources/se/diabol/jenkins/pipeline/DeliveryPipelineView/ComponentSpec/config.jelly
+++ b/src/main/resources/se/diabol/jenkins/pipeline/DeliveryPipelineView/ComponentSpec/config.jelly
@@ -11,6 +11,9 @@
         <f:entry title="Final Job (optional)" field="lastJob">
             <f:select/>
         </f:entry>
+        <f:entry title="Exclude jobs regular expression">
+            <f:textbox field="excludeJobsRegex"/>
+        </f:entry>
         <div align="right">
             <f:repeatableDeleteButton/>
         </div>

--- a/src/test/java/se/diabol/jenkins/pipeline/DeliveryPipelineViewTest.java
+++ b/src/test/java/se/diabol/jenkins/pipeline/DeliveryPipelineViewTest.java
@@ -91,8 +91,8 @@ public class DeliveryPipelineViewTest {
         FreeStyleProject p1 = jenkins.createFreeStyleProject("build1");
 
         List<DeliveryPipelineView.ComponentSpec> componentSpecs = new ArrayList<DeliveryPipelineView.ComponentSpec>();
-        componentSpecs.add(new DeliveryPipelineView.ComponentSpec("comp1", "build1", NONE));
-        componentSpecs.add(new DeliveryPipelineView.ComponentSpec("comp2", "build2", NONE));
+        componentSpecs.add(new DeliveryPipelineView.ComponentSpec("comp1", "build1", NONE, NONE));
+        componentSpecs.add(new DeliveryPipelineView.ComponentSpec("comp2", "build2", NONE, NONE));
 
         DeliveryPipelineView view = new DeliveryPipelineView("Test");
         view.setComponentSpecs(componentSpecs);
@@ -109,7 +109,7 @@ public class DeliveryPipelineViewTest {
         FreeStyleProject p2 = jenkins.createFreeStyleProject("build2");
 
         List<DeliveryPipelineView.ComponentSpec> componentSpecs = new ArrayList<DeliveryPipelineView.ComponentSpec>();
-        componentSpecs.add(new DeliveryPipelineView.ComponentSpec("comp1", "build1", "build2"));
+        componentSpecs.add(new DeliveryPipelineView.ComponentSpec("comp1", "build1", "build2", NONE));
 
         DeliveryPipelineView view = new DeliveryPipelineView("Test");
         view.setComponentSpecs(componentSpecs);
@@ -140,8 +140,8 @@ public class DeliveryPipelineViewTest {
         FreeStyleProject p1 = jenkins.createFreeStyleProject("build1");
 
         List<DeliveryPipelineView.ComponentSpec> componentSpecs = new ArrayList<DeliveryPipelineView.ComponentSpec>();
-        componentSpecs.add(new DeliveryPipelineView.ComponentSpec("comp1", "build1", NONE));
-        componentSpecs.add(new DeliveryPipelineView.ComponentSpec("comp2", "build2", NONE));
+        componentSpecs.add(new DeliveryPipelineView.ComponentSpec("comp1", "build1", NONE, NONE));
+        componentSpecs.add(new DeliveryPipelineView.ComponentSpec("comp2", "build2", NONE, NONE));
 
         DeliveryPipelineView view = new DeliveryPipelineView("Test");
         view.setComponentSpecs(componentSpecs);
@@ -163,8 +163,8 @@ public class DeliveryPipelineViewTest {
         when(request.getSubmittedForm()).thenReturn(new JSONObject());
         view.submit(request);
         verify(request, times(1)).bindJSON(view, new JSONObject());
-        verify(request, times(1)).bindJSONToList(DeliveryPipelineView.ComponentSpec.class, null);
-        verify(request, times(1)).bindJSONToList(DeliveryPipelineView.RegExpSpec.class, null);
+        verify(request, times(1)).bindJSONToList(DeliveryPipelineView.ComponentSpec.class, NONE);
+        verify(request, times(1)).bindJSONToList(DeliveryPipelineView.RegExpSpec.class, NONE);
     }
 
 
@@ -281,7 +281,7 @@ public class DeliveryPipelineViewTest {
 
 
         List<DeliveryPipelineView.ComponentSpec> specs = new ArrayList<DeliveryPipelineView.ComponentSpec>();
-        specs.add(new DeliveryPipelineView.ComponentSpec("Comp", "build", NONE));
+        specs.add(new DeliveryPipelineView.ComponentSpec("Comp", "build", NONE, NONE));
         DeliveryPipelineView view = new DeliveryPipelineView("name");
         view.setComponentSpecs(specs);
         jenkins.getInstance().addView(view);
@@ -298,7 +298,7 @@ public class DeliveryPipelineViewTest {
     @Test
     public void testGetItemsGetPipelinesWhenNoProjectFound() throws Exception {
         List<DeliveryPipelineView.ComponentSpec> specs = new ArrayList<DeliveryPipelineView.ComponentSpec>();
-        specs.add(new DeliveryPipelineView.ComponentSpec("Comp", "build", NONE));
+        specs.add(new DeliveryPipelineView.ComponentSpec("Comp", "build", NONE, NONE));
         DeliveryPipelineView view = new DeliveryPipelineView("name");
         view.setComponentSpecs(specs);
         jenkins.getInstance().addView(view);
@@ -328,7 +328,7 @@ public class DeliveryPipelineViewTest {
 
 
         List<DeliveryPipelineView.ComponentSpec> specs = new ArrayList<DeliveryPipelineView.ComponentSpec>();
-        specs.add(new DeliveryPipelineView.ComponentSpec("Comp", "build", NONE));
+        specs.add(new DeliveryPipelineView.ComponentSpec("Comp", "build", NONE, NONE));
         DeliveryPipelineView view = new DeliveryPipelineView("name");
         view.setComponentSpecs(specs);
         folder.addView(view);
@@ -356,7 +356,7 @@ public class DeliveryPipelineViewTest {
         jenkins.waitUntilNoActivity();
 
         List<DeliveryPipelineView.ComponentSpec> specs = new ArrayList<DeliveryPipelineView.ComponentSpec>();
-        specs.add(new DeliveryPipelineView.ComponentSpec("Comp", "build", "test"));
+        specs.add(new DeliveryPipelineView.ComponentSpec("Comp", "build", "test", NONE));
         DeliveryPipelineView view = new DeliveryPipelineView("Pipeline");
         view.setComponentSpecs(specs);
         view.setSorting(NameComparator.class.getName());
@@ -370,7 +370,7 @@ public class DeliveryPipelineViewTest {
         FreeStyleProject build = jenkins.createFreeStyleProject("build");
         build.addProperty(new PipelineProperty("Build", "BuildStage", ""));
         List<DeliveryPipelineView.ComponentSpec> specs = new ArrayList<DeliveryPipelineView.ComponentSpec>();
-        specs.add(new DeliveryPipelineView.ComponentSpec("Comp", "build", NONE));
+        specs.add(new DeliveryPipelineView.ComponentSpec("Comp", "build", NONE, NONE));
         DeliveryPipelineView view = new DeliveryPipelineView("Pipeline");
         view.setComponentSpecs(specs);
         view.setSorting(NameComparator.class.getName());
@@ -697,7 +697,7 @@ public class DeliveryPipelineViewTest {
 
         DeliveryPipelineView view = new DeliveryPipelineView("Pipeline");
         List<DeliveryPipelineView.ComponentSpec> componentSpecs = new ArrayList<DeliveryPipelineView.ComponentSpec>();
-        componentSpecs.add(new DeliveryPipelineView.ComponentSpec("Comp", "A", NONE));
+        componentSpecs.add(new DeliveryPipelineView.ComponentSpec("Comp", "A", NONE, NONE));
         view.setComponentSpecs(componentSpecs);
 
         jenkins.getInstance().addView(view);
@@ -718,8 +718,8 @@ public class DeliveryPipelineViewTest {
 
         DeliveryPipelineView view = new DeliveryPipelineView("Pipeline");
         List<DeliveryPipelineView.ComponentSpec> componentSpecs = new ArrayList<DeliveryPipelineView.ComponentSpec>();
-        componentSpecs.add(new DeliveryPipelineView.ComponentSpec("Comp2", "A", NONE));
-        componentSpecs.add(new DeliveryPipelineView.ComponentSpec("Comp1", "B", NONE));
+        componentSpecs.add(new DeliveryPipelineView.ComponentSpec("Comp2", "A", NONE, NONE));
+        componentSpecs.add(new DeliveryPipelineView.ComponentSpec("Comp1", "B", NONE, NONE));
         view.setComponentSpecs(componentSpecs);
         view.setShowAggregatedPipeline(true);
         view.setSorting("this will not be found");
@@ -745,8 +745,8 @@ public class DeliveryPipelineViewTest {
 
         DeliveryPipelineView view = new DeliveryPipelineView("Pipeline");
         List<DeliveryPipelineView.ComponentSpec> componentSpecs = new ArrayList<DeliveryPipelineView.ComponentSpec>();
-        componentSpecs.add(new DeliveryPipelineView.ComponentSpec("Comp2", "A", NONE));
-        componentSpecs.add(new DeliveryPipelineView.ComponentSpec("Comp1", "B", NONE));
+        componentSpecs.add(new DeliveryPipelineView.ComponentSpec("Comp2", "A", NONE, NONE));
+        componentSpecs.add(new DeliveryPipelineView.ComponentSpec("Comp1", "B", NONE, NONE));
         view.setComponentSpecs(componentSpecs);
         view.setShowAggregatedPipeline(true);
         view.setSorting("none");

--- a/src/test/java/se/diabol/jenkins/pipeline/domain/PipelineTest.java
+++ b/src/test/java/se/diabol/jenkins/pipeline/domain/PipelineTest.java
@@ -20,6 +20,8 @@ package se.diabol.jenkins.pipeline.domain;
 import au.com.centrumsystems.hudson.plugin.buildpipeline.BuildPipelineView;
 import au.com.centrumsystems.hudson.plugin.buildpipeline.DownstreamProjectGridBuilder;
 import au.com.centrumsystems.hudson.plugin.buildpipeline.trigger.BuildPipelineTrigger;
+import com.google.common.base.Throwables;
+import com.google.common.collect.Iterables;
 import hudson.model.Cause;
 import hudson.model.Descriptor;
 import hudson.model.FreeStyleProject;
@@ -49,10 +51,13 @@ import se.diabol.jenkins.pipeline.domain.status.Status;
 import se.diabol.jenkins.pipeline.domain.task.Task;
 import se.diabol.jenkins.pipeline.util.BuildUtil;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import static com.google.common.collect.Lists.newArrayList;
+import static com.google.gson.internal.$Gson$Preconditions.checkArgument;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
@@ -816,6 +821,49 @@ public class PipelineTest {
         Pipeline pipeline = new Pipeline("NoStages", project, null, new ArrayList<Stage>());
         pipeline.calculateTotalBuildTime();
         assertEquals(0L, pipeline.getTotalBuildTime());
+    }
+
+    @Test
+    public void testExtractExcludeJobsRegex() throws Exception {
+        String firstJobName = "project-build";
+        List<String> expectedJobNames = newArrayList(firstJobName, "project-country1-test", "project-country1-deploy");
+        createLinkedProjects(expectedJobNames);
+        createLinkedProjects(newArrayList(firstJobName, "project-country2-test", "project-country2-deploy"));
+        jenkins.getInstance().rebuildDependencyGraph();
+        FreeStyleProject firstJob = getOrCreateProject(firstJobName);
+
+        Pipeline pipeline = Pipeline.extractPipeline("Pipeline", firstJob, null, "project-(?!build|country1).*");
+
+        assertEquals(expectedJobNames, getProjectNames(pipeline));
+    }
+
+    private void createLinkedProjects(List<String> projectNames) {
+        checkArgument(projectNames.size() > 0);
+        FreeStyleProject fromProject = getOrCreateProject(projectNames.get(0));
+        Iterable<String> subsequentProjectNames = Iterables.skip(projectNames, 1);
+        for (String toProjectName : subsequentProjectNames) {
+            fromProject.getPublishersList().add(new BuildTrigger(toProjectName, false));
+            fromProject = getOrCreateProject(toProjectName);
+        }
+    }
+
+    private FreeStyleProject getOrCreateProject(String projectName) {
+        FreeStyleProject existingProject = jenkins.getInstance().getItemByFullName(projectName, FreeStyleProject.class);
+        try {
+            return existingProject != null ? existingProject : jenkins.createFreeStyleProject(projectName);
+        } catch (IOException e) {
+            throw Throwables.propagate(e);
+        }
+    }
+
+    private List<String> getProjectNames(Pipeline pipeline) {
+        List<String> projectNames = newArrayList();
+        for (Stage stage : pipeline.getStages()) {
+            for (Task task : stage.getTasks()) {
+                projectNames.add(task.getName());
+            }
+        }
+        return projectNames;
     }
 
 }

--- a/src/test/java/se/diabol/jenkins/pipeline/domain/StageTest.java
+++ b/src/test/java/se/diabol/jenkins/pipeline/domain/StageTest.java
@@ -199,7 +199,7 @@ public class StageTest {
         Collection<MatrixConfiguration> configurations = project.getActiveConfigurations();
 
         for (MatrixConfiguration configuration : configurations) {
-            List<Stage> stages = Stage.extractStages(configuration, null);
+            List<Stage> stages = Stage.extractStages(configuration, null, null);
             assertEquals(1, stages.size());
             Stage stage = stages.get(0);
             assertEquals("stage", stage.getName());

--- a/src/test/java/se/diabol/jenkins/pipeline/functionaltest/GuiFunctionalIT.java
+++ b/src/test/java/se/diabol/jenkins/pipeline/functionaltest/GuiFunctionalIT.java
@@ -71,7 +71,7 @@ public class GuiFunctionalIT {
 
         DeliveryPipelineView view = new DeliveryPipelineView("Pipeline");
         List<DeliveryPipelineView.ComponentSpec> specs = new ArrayList<DeliveryPipelineView.ComponentSpec>();
-        specs.add(new DeliveryPipelineView.ComponentSpec("Component", "A", NONE));
+        specs.add(new DeliveryPipelineView.ComponentSpec("Component", "A", NONE, NONE));
         view.setComponentSpecs(specs);
         view.setAllowManualTriggers(true);
 
@@ -98,7 +98,7 @@ public class GuiFunctionalIT {
 
         DeliveryPipelineView view = new DeliveryPipelineView("Pipeline");
         List<DeliveryPipelineView.ComponentSpec> specs = new ArrayList<DeliveryPipelineView.ComponentSpec>();
-        specs.add(new DeliveryPipelineView.ComponentSpec("Component", "A", NONE));
+        specs.add(new DeliveryPipelineView.ComponentSpec("Component", "A", NONE, NONE));
         view.setComponentSpecs(specs);
         view.setAllowManualTriggers(true);
         view.setAllowRebuild(true);
@@ -131,7 +131,7 @@ public class GuiFunctionalIT {
 
         DeliveryPipelineView view = new DeliveryPipelineView("Pipeline");
         List<DeliveryPipelineView.ComponentSpec> specs = new ArrayList<DeliveryPipelineView.ComponentSpec>();
-        specs.add(new DeliveryPipelineView.ComponentSpec("Component", "A", NONE));
+        specs.add(new DeliveryPipelineView.ComponentSpec("Component", "A", NONE, NONE));
         view.setComponentSpecs(specs);
         view.setAllowManualTriggers(true);
         view.setAllowRebuild(true);
@@ -172,7 +172,7 @@ public class GuiFunctionalIT {
 
         DeliveryPipelineView view = new DeliveryPipelineView("Pipeline");
         List<DeliveryPipelineView.ComponentSpec> specs = new ArrayList<DeliveryPipelineView.ComponentSpec>();
-        specs.add(new DeliveryPipelineView.ComponentSpec("Component", "Start", NONE));
+        specs.add(new DeliveryPipelineView.ComponentSpec("Component", "Start", NONE, NONE));
         view.setComponentSpecs(specs);
         view.setAllowPipelineStart(true);
 
@@ -199,7 +199,7 @@ public class GuiFunctionalIT {
 
         DeliveryPipelineView view = new DeliveryPipelineView("Pipeline");
         List<DeliveryPipelineView.ComponentSpec> specs = new ArrayList<DeliveryPipelineView.ComponentSpec>();
-        specs.add(new DeliveryPipelineView.ComponentSpec("Component", "Start", NONE));
+        specs.add(new DeliveryPipelineView.ComponentSpec("Component", "Start", NONE, NONE));
         view.setComponentSpecs(specs);
         view.setAllowPipelineStart(true);
 
@@ -228,7 +228,7 @@ public class GuiFunctionalIT {
 
         DeliveryPipelineView view = new DeliveryPipelineView("Pipeline");
         List<DeliveryPipelineView.ComponentSpec> specs = new ArrayList<DeliveryPipelineView.ComponentSpec>();
-        specs.add(new DeliveryPipelineView.ComponentSpec("Component", "Start", NONE));
+        specs.add(new DeliveryPipelineView.ComponentSpec("Component", "Start", NONE, NONE));
         view.setComponentSpecs(specs);
         view.setAllowPipelineStart(true);
 


### PR DESCRIPTION
Our use case is as follows: our projects have multiple instances (one per country), but the deployed artifact is basically the same. Hence, there is one build-and-publish job with multiple downstreams. E.g. (simplified):

project-build-and-publish
|-> project-country1-test -> project-country1-deploy
|-> project-country2-test -> project-country2-deploy

This PR might also partially solve https://issues.jenkins-ci.org/browse/JENKINS-26210.