### PR TITLE
Ability to hide tasks in stages from pipeline view using Delivery Pip…

### DIFF
--- a/src/main/java/se/diabol/jenkins/pipeline/DeliveryPipelineView.java
+++ b/src/main/java/se/diabol/jenkins/pipeline/DeliveryPipelineView.java
@@ -453,7 +453,7 @@ public class DeliveryPipelineView extends View {
     }
 
     private Component getComponent(String name, AbstractProject firstJob, AbstractProject lastJob, boolean showAggregatedPipeline) throws PipelineException {
-        Pipeline pipeline = Pipeline.extractPipeline(name, firstJob, lastJob);
+        Pipeline pipeline = Pipeline.extractPipeline(name, firstJob, lastJob, showHiddenTasks);
         List<Pipeline> pipelines = new ArrayList<Pipeline>();
         if (showAggregatedPipeline) {
             pipelines.add(pipeline.createPipelineAggregated(getOwnerItemGroup()));

--- a/src/main/java/se/diabol/jenkins/pipeline/DeliveryPipelineView.java
+++ b/src/main/java/se/diabol/jenkins/pipeline/DeliveryPipelineView.java
@@ -105,6 +105,7 @@ public class DeliveryPipelineView extends View {
     private boolean showPromotions = false;
     private boolean showTestResults = false;
     private boolean showStaticAnalysisResults = false;
+	private boolean showHiddenTasks = false;
 
     private List<RegExpSpec> regexpFirstJobs;
 
@@ -184,7 +185,16 @@ public class DeliveryPipelineView extends View {
     public boolean isShowTotalBuildTime() {
         return showTotalBuildTime;
     }
+	
+	@Exported
+	public boolean getShowHiddenTasks() {
+		return showHiddenTasks;
+	}
 
+	public void setShowHiddenTasks(boolean showHiddenTasks) {
+		this.showHiddenTasks = showHiddenTasks;
+	}
+	
     public void setShowTotalBuildTime(boolean showTotalBuildTime) {
         this.showTotalBuildTime = showTotalBuildTime;
     }

--- a/src/main/java/se/diabol/jenkins/pipeline/PipelineProperty.java
+++ b/src/main/java/se/diabol/jenkins/pipeline/PipelineProperty.java
@@ -164,10 +164,7 @@ public class PipelineProperty extends JobProperty<AbstractProject<?, ?>> {
             }
             if ("".equals(description)) {
                 description = null;
-            }
-            if (task == null && stage == null) {
-                return null;
-            }
+            }           
             return new PipelineProperty(task, stage, description, hideTask);
         }
     }

--- a/src/main/java/se/diabol/jenkins/pipeline/PipelineProperty.java
+++ b/src/main/java/se/diabol/jenkins/pipeline/PipelineProperty.java
@@ -37,15 +37,17 @@ public class PipelineProperty extends JobProperty<AbstractProject<?, ?>> {
     private String taskName = null;
     private String stageName = null;
     private String descriptionTemplate = null;
+	private boolean hideTask = false;
 
     public PipelineProperty() {
     }
 
     @DataBoundConstructor
-    public PipelineProperty(String taskName, String stageName, String descriptionTemplate) {
+    public PipelineProperty(String taskName, String stageName, String descriptionTemplate, boolean hideTask) {
         setStageName(stageName);
         setTaskName(taskName);
         setDescriptionTemplate(descriptionTemplate);
+		setHideTask(hideTask);
     }
 
     @Exported
@@ -62,6 +64,11 @@ public class PipelineProperty extends JobProperty<AbstractProject<?, ?>> {
     public String getDescriptionTemplate() {
         return descriptionTemplate;
     }
+	
+	@Exported
+	public boolean getHideTask() {
+		return hideTask;
+	}
 
     public final void setTaskName(String taskName) {
         this.taskName = taskName;
@@ -87,6 +94,10 @@ public class PipelineProperty extends JobProperty<AbstractProject<?, ?>> {
         }
         return result;
     }
+	
+	public final void setHideTask(boolean hideTask) {
+		this.hideTask = hideTask;
+	}
 
     @Extension
     public static final class DescriptorImpl extends JobPropertyDescriptor {
@@ -140,6 +151,7 @@ public class PipelineProperty extends JobProperty<AbstractProject<?, ?>> {
             String task = sr.getParameter("taskName");
             String stage = sr.getParameter("stageName");
             String description = sr.getParameter("descriptionTemplate");
+			boolean hideTask = sr.getParameter("hideTask") != null;
             boolean configEnabled = sr.getParameter("enabled") != null;
             if (!configEnabled) {
                 return null;
@@ -156,7 +168,7 @@ public class PipelineProperty extends JobProperty<AbstractProject<?, ?>> {
             if (task == null && stage == null) {
                 return null;
             }
-            return new PipelineProperty(task, stage, description);
+            return new PipelineProperty(task, stage, description, hideTask);
         }
     }
 }

--- a/src/main/java/se/diabol/jenkins/pipeline/domain/Pipeline.java
+++ b/src/main/java/se/diabol/jenkins/pipeline/domain/Pipeline.java
@@ -187,11 +187,13 @@ public class Pipeline extends AbstractItem {
      * Created a pipeline prototype for the supplied first project
      */
     public static Pipeline extractPipeline(String name, AbstractProject<?, ?> firstProject, AbstractProject<?, ?> lastProject) throws PipelineException {
-        return new Pipeline(name, firstProject, lastProject, newArrayList(Stage.extractStages(firstProject, lastProject)));
+        List<Stage> stages = Stage.extractStages(firstProject, lastProject);
+        return new Pipeline(name, firstProject, lastProject, newArrayList(stages));
     }
 
     public static Pipeline extractPipeline(String name, AbstractProject<?, ?> firstProject) throws PipelineException {
-        return new Pipeline(name, firstProject, null, newArrayList(Stage.extractStages(firstProject, null)));
+        List<Stage> stages = Stage.extractStages(firstProject, null);
+        return new Pipeline(name, firstProject, null, newArrayList(stages));
     }
 
     public Pipeline createPipelineAggregated(ItemGroup context) {

--- a/src/main/java/se/diabol/jenkins/pipeline/domain/Pipeline.java
+++ b/src/main/java/se/diabol/jenkins/pipeline/domain/Pipeline.java
@@ -186,13 +186,13 @@ public class Pipeline extends AbstractItem {
     /**
      * Created a pipeline prototype for the supplied first project
      */
-    public static Pipeline extractPipeline(String name, AbstractProject<?, ?> firstProject, AbstractProject<?, ?> lastProject) throws PipelineException {
-        List<Stage> stages = Stage.extractStages(firstProject, lastProject);
+    public static Pipeline extractPipeline(String name, AbstractProject<?, ?> firstProject, AbstractProject<?, ?> lastProject, boolean showHiddenTasks) throws PipelineException {
+        List<Stage> stages = Stage.extractStages(firstProject, lastProject, showHiddenTasks);
         return new Pipeline(name, firstProject, lastProject, newArrayList(stages));
     }
 
-    public static Pipeline extractPipeline(String name, AbstractProject<?, ?> firstProject) throws PipelineException {
-        List<Stage> stages = Stage.extractStages(firstProject, null);
+    public static Pipeline extractPipeline(String name, AbstractProject<?, ?> firstProject, boolean showHiddenTasks) throws PipelineException {
+        List<Stage> stages = Stage.extractStages(firstProject, null, showHiddenTasks);
         return new Pipeline(name, firstProject, null, newArrayList(stages));
     }
 

--- a/src/main/java/se/diabol/jenkins/pipeline/domain/Stage.java
+++ b/src/main/java/se/diabol/jenkins/pipeline/domain/Stage.java
@@ -155,13 +155,14 @@ public class Stage extends AbstractItem {
         return new Stage(name, tasks);
     }
 
-    public static List<Stage> extractStages(AbstractProject firstProject, AbstractProject lastProject) throws PipelineException {
+    public static List<Stage> extractStages(AbstractProject firstProject, AbstractProject lastProject, boolean showHiddenTasks) throws PipelineException {
         Map<String, Stage> stages = newLinkedHashMap();
         for (AbstractProject project : ProjectUtil.getAllDownstreamProjects(firstProject, lastProject).values()) {
 			PipelineProperty dproperty = (PipelineProperty) project.getProperty(PipelineProperty.class);
 			boolean hideTask = dproperty != null ? dproperty.getHideTask() : false;
+			if(showHiddenTasks) hideTask = false;
 			if(!hideTask) {
-				Task task = Task.getPrototypeTask(project, project.getFullName().equals(firstProject.getFullName()));
+				Task task = Task.getPrototypeTask(project, project.getFullName().equals(firstProject.getFullName()), showHiddenTasks);
 				/* if current project is last we need clean downStreamTasks*/
 				if (lastProject != null && project.getFullName().equals(lastProject.getFullName())) {
 					task.getDownstreamTasks().clear();

--- a/src/main/java/se/diabol/jenkins/pipeline/domain/Stage.java
+++ b/src/main/java/se/diabol/jenkins/pipeline/domain/Stage.java
@@ -158,24 +158,28 @@ public class Stage extends AbstractItem {
     public static List<Stage> extractStages(AbstractProject firstProject, AbstractProject lastProject) throws PipelineException {
         Map<String, Stage> stages = newLinkedHashMap();
         for (AbstractProject project : ProjectUtil.getAllDownstreamProjects(firstProject, lastProject).values()) {
-            Task task = Task.getPrototypeTask(project, project.getFullName().equals(firstProject.getFullName()));
-            /* if current project is last we need clean downStreamTasks*/
-            if (lastProject != null && project.getFullName().equals(lastProject.getFullName())) {
-                task.getDownstreamTasks().clear();
-            }
+			PipelineProperty dproperty = (PipelineProperty) project.getProperty(PipelineProperty.class);
+			boolean hideTask = dproperty != null ? dproperty.getHideTask() : false;
+			if(!hideTask) {
+				Task task = Task.getPrototypeTask(project, project.getFullName().equals(firstProject.getFullName()));
+				/* if current project is last we need clean downStreamTasks*/
+				if (lastProject != null && project.getFullName().equals(lastProject.getFullName())) {
+					task.getDownstreamTasks().clear();
+				}
 
-            PipelineProperty property = (PipelineProperty) project.getProperty(PipelineProperty.class);
-            if (property == null && project.getParent() instanceof AbstractProject) {
-                property = (PipelineProperty) ((AbstractProject) project.getParent()).getProperty(PipelineProperty.class);
-            }
-            String stageName = property != null && !isNullOrEmpty(property.getStageName())
-                    ? property.getStageName() : project.getDisplayName();
-            Stage stage = stages.get(stageName);
-            if (stage == null) {
-                stage = Stage.getPrototypeStage(stageName, Collections.<Task>emptyList());
-            }
-            stages.put(stageName,
-                    Stage.getPrototypeStage(stage.getName(), newArrayList(concat(stage.getTasks(), singleton(task)))));
+				PipelineProperty property = (PipelineProperty) project.getProperty(PipelineProperty.class);
+				if (property == null && project.getParent() instanceof AbstractProject) {
+					property = (PipelineProperty) ((AbstractProject) project.getParent()).getProperty(PipelineProperty.class);
+				}
+				String stageName = property != null && !isNullOrEmpty(property.getStageName())
+						? property.getStageName() : project.getDisplayName();
+				Stage stage = stages.get(stageName);
+				if (stage == null) {
+					stage = Stage.getPrototypeStage(stageName, Collections.<Task>emptyList());
+				}
+				stages.put(stageName,
+						Stage.getPrototypeStage(stage.getName(), newArrayList(concat(stage.getTasks(), singleton(task)))));
+			}
         }
         Collection<Stage> stagesResult = stages.values();
 
@@ -337,14 +341,41 @@ public class Stage extends AbstractItem {
     private static List<Stage> getDownstreamStages(Stage stage, Collection<Stage> stages) {
         List<Stage> result = newArrayList();
         for (int i = 0; i < stage.getTasks().size(); i++) {
-            Task task = stage.getTasks().get(i);
-            for (int j = 0; j < task.getDownstreamTasks().size(); j++) {
-                String jobName = task.getDownstreamTasks().get(j);
-                Stage target = findStageForJob(jobName, stages);
-                if (target != null && !target.getName().equals(stage.getName())) {
-                    result.add(target);
-                }
-            }
+            Task task = stage.getTasks().get(i);		
+			if(task.getDownstreamTasks().size() > 0)
+			{
+				for (int j = 0; j < task.getDownstreamTasks().size(); j++) {				
+					String jobName = task.getDownstreamTasks().get(j);				
+					Stage target = findStageForJob(jobName, stages);
+					if (target != null && !target.getName().equals(stage.getName())) {
+						result.add(target);
+					}
+				}
+			}
+			else
+			{
+				AbstractProject project = ProjectUtil.getProject(task.getId(), Jenkins.getInstance()); 
+				List<AbstractProject> downStreams = ProjectUtil.getDownstreamProjects(project);
+				if(downStreams.size() > 0)
+				{
+					for(int j=0; j < downStreams.size(); j++)
+					{
+						AbstractProject downStreamProject = downStreams.get(j);
+						List<AbstractProject> subDownStreamProject = ProjectUtil.getDownstreamProjects(downStreamProject);
+						if(subDownStreamProject.size() > 0)
+						{	
+							for(int k = 0; k < subDownStreamProject.size(); k++)
+							{
+								Stage target = findStageForJob(subDownStreamProject.get(k).getRelativeNameFrom(Jenkins.getInstance()), stages);
+								if (target != null && !target.getName().equals(stage.getName())) {
+									result.add(target);
+								}
+							}							
+						}						
+					}					
+				}
+				
+			}            
         }
         return result;
     }

--- a/src/main/java/se/diabol/jenkins/pipeline/domain/task/Task.java
+++ b/src/main/java/se/diabol/jenkins/pipeline/domain/task/Task.java
@@ -171,16 +171,14 @@ public class Task extends AbstractItem {
         PipelineProperty property = (PipelineProperty) project.getProperty(PipelineProperty.class);
         String taskName = property != null && !isNullOrEmpty(property.getTaskName())
                 ? property.getTaskName() : project.getDisplayName();
-				
 		boolean hideTask = property != null ? property.getHideTask() : false;
-
         if (property == null && project.getParent() instanceof AbstractProject) {
             property = (PipelineProperty) ((AbstractProject) project.getParent()).getProperty(PipelineProperty.class);
             taskName = property != null && !isNullOrEmpty(property.getTaskName())
                     ? property.getTaskName() + " " + project.getName() : project.getDisplayName();
 			hideTask = property != null ? property.getHideTask() : false;
         }
-
+		
         String descriptionTemplate = property != null && !isNullOrEmpty(property.getDescriptionTemplate())
                 ? property.getDescriptionTemplate() : "";
 
@@ -188,7 +186,10 @@ public class Task extends AbstractItem {
         List<AbstractProject> downStreams = ProjectUtil.getDownstreamProjects(project);
         List<String> downStreamTasks = new ArrayList<String>();
         for (AbstractProject downstreamProject : downStreams) {
-            downStreamTasks.add(downstreamProject.getRelativeNameFrom(Jenkins.getInstance()));
+			PipelineProperty dproperty = (PipelineProperty) downstreamProject.getProperty(PipelineProperty.class);
+			boolean dhideTask = dproperty != null ? dproperty.getHideTask() : false;	
+			if(!dhideTask)		
+			downStreamTasks.add(downstreamProject.getRelativeNameFrom(Jenkins.getInstance()));			
         }
         return new Task(project, project.getRelativeNameFrom(Jenkins.getInstance()), taskName, status,
                 project.getUrl(), ManualStep.resolveManualStep(project), downStreamTasks, initial, descriptionTemplate, hideTask);

--- a/src/main/java/se/diabol/jenkins/pipeline/domain/task/Task.java
+++ b/src/main/java/se/diabol/jenkins/pipeline/domain/task/Task.java
@@ -167,7 +167,7 @@ public class Task extends AbstractItem {
         return initial;
     }
 
-    public static Task getPrototypeTask(AbstractProject project, boolean initial) {
+    public static Task getPrototypeTask(AbstractProject project, boolean initial, boolean showHiddenTasks) {
         PipelineProperty property = (PipelineProperty) project.getProperty(PipelineProperty.class);
         String taskName = property != null && !isNullOrEmpty(property.getTaskName())
                 ? property.getTaskName() : project.getDisplayName();
@@ -188,6 +188,7 @@ public class Task extends AbstractItem {
         for (AbstractProject downstreamProject : downStreams) {
 			PipelineProperty dproperty = (PipelineProperty) downstreamProject.getProperty(PipelineProperty.class);
 			boolean dhideTask = dproperty != null ? dproperty.getHideTask() : false;	
+			if(showHiddenTasks) dhideTask = false;
 			if(!dhideTask)		
 			downStreamTasks.add(downstreamProject.getRelativeNameFrom(Jenkins.getInstance()));			
         }

--- a/src/main/resources/se/diabol/jenkins/pipeline/DeliveryPipelineView/configure-entries.jelly
+++ b/src/main/resources/se/diabol/jenkins/pipeline/DeliveryPipelineView/configure-entries.jelly
@@ -64,6 +64,10 @@
         <f:entry title="Show total build time" field="showTotalBuildTime">
             <f:checkbox/>
         </f:entry>
+		
+		<f:entry title="Show Hidden Tasks" field="showHiddenTasks">
+            <f:checkbox/>
+        </f:entry>
 
         <f:entry title="URL for custom CSS file" field="embeddedCss">
             <f:textbox/>

--- a/src/main/resources/se/diabol/jenkins/pipeline/DeliveryPipelineView/help-showHiddenTasks.html
+++ b/src/main/resources/se/diabol/jenkins/pipeline/DeliveryPipelineView/help-showHiddenTasks.html
@@ -1,0 +1,4 @@
+<div>
+    Show all tasks in pipeline.<br/>
+    If there are any job configuration opted for hide tasks from pipeline, this option overrides and shows all Tasks in pipeline.
+</div>

--- a/src/main/resources/se/diabol/jenkins/pipeline/DeliveryPipelineView/help-showHiddenTasks.html
+++ b/src/main/resources/se/diabol/jenkins/pipeline/DeliveryPipelineView/help-showHiddenTasks.html
@@ -1,4 +1,4 @@
 <div>
     Show all tasks in pipeline.<br/>
-    If there are any job configuration opted for hide tasks from pipeline, this option overrides and shows all Tasks in pipeline.
+    If there are any job configuration opted for hide task in pipeline, this option overrides and shows all Tasks in pipeline.
 </div>

--- a/src/main/resources/se/diabol/jenkins/pipeline/PipelineProperty/config.jelly
+++ b/src/main/resources/se/diabol/jenkins/pipeline/PipelineProperty/config.jelly
@@ -9,6 +9,10 @@
             <f:entry title="Task Name" field="taskName">
                 <f:textbox name="taskName" value="${instance.getTaskName()}"/>
             </f:entry>
+			
+			<f:entry title="Hide Task" field="hideTask">
+				<f:checkbox name="hideTask" checked="${instance.getHideTask()}"/>
+			</f:entry>
 
             <f:entry title="Customize Task Description Template" field="descriptionTemplate">
                 <f:textarea name="descriptionTemplate" value="${instance.getDescriptionTemplate()}"/>

--- a/src/main/resources/se/diabol/jenkins/pipeline/PipelineProperty/help-hideTask.jelly
+++ b/src/main/resources/se/diabol/jenkins/pipeline/PipelineProperty/help-hideTask.jelly
@@ -1,0 +1,7 @@
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
+         xmlns:t="/lib/hudson" xmlns:f="/lib/form">    
+    <div>        
+        <p>Check to hide this task in build Delivery Pipeline View.</p>
+    </div>
+    
+</j:jelly>

--- a/src/main/webapp/pipe.js
+++ b/src/main/webapp/pipe.js
@@ -49,6 +49,25 @@ function refreshPipelines(data, divNames, errorDiv, view, showAvatars, showChang
         }
 
         plumb.reset();
+		for(var c = 0; c < data.pipelines.length; c++) {
+			component = data.pipelines[c];
+			for(var i=0; i< component.pipelines.length; i++) {
+				pipeline = component.pipelines[i];	
+				for (var j = 0; j < pipeline.stages.length; j++) {
+					var l = [];
+					var stage = pipeline.stages[j];
+					for (var k = 0; k < stage.tasks.length; k++) {
+						task = stage.tasks[k];
+						if(task.hideTask) {
+							l.push(task);
+						}
+					}
+					for(var m = 0; m < l.length; m++) {
+						stage.tasks.splice(Q.inArray(l[m], stage.tasks),1);
+					}
+				}
+			}
+		}	
         for (var c = 0; c < data.pipelines.length; c++) {
             html = [];
             component = data.pipelines[c];

--- a/src/main/webapp/pipe.js
+++ b/src/main/webapp/pipe.js
@@ -48,28 +48,7 @@ function refreshPipelines(data, divNames, errorDiv, view, showAvatars, showChang
             Q("#pipeline-message").html('No pipelines configured or found. Please review the <a href="configure">configuration</a>')
         }
 
-        plumb.reset();
-		if(!data.showHiddenTasks) {
-			for(var c = 0; c < data.pipelines.length; c++) {
-				component = data.pipelines[c];
-				for(var i=0; i< component.pipelines.length; i++) {
-					pipeline = component.pipelines[i];	
-					for (var j = 0; j < pipeline.stages.length; j++) {
-						var l = [];
-						var stage = pipeline.stages[j];
-						for (var k = 0; k < stage.tasks.length; k++) {
-							task = stage.tasks[k];
-							if(task.hideTask) {
-								l.push(task);
-							}
-						}
-						for(var m = 0; m < l.length; m++) {
-							stage.tasks.splice(Q.inArray(l[m], stage.tasks),1);
-						}
-					}
-				}
-			}	
-		}
+        plumb.reset();		
         for (var c = 0; c < data.pipelines.length; c++) {
             html = [];
             component = data.pipelines[c];

--- a/src/main/webapp/pipe.js
+++ b/src/main/webapp/pipe.js
@@ -49,25 +49,27 @@ function refreshPipelines(data, divNames, errorDiv, view, showAvatars, showChang
         }
 
         plumb.reset();
-		for(var c = 0; c < data.pipelines.length; c++) {
-			component = data.pipelines[c];
-			for(var i=0; i< component.pipelines.length; i++) {
-				pipeline = component.pipelines[i];	
-				for (var j = 0; j < pipeline.stages.length; j++) {
-					var l = [];
-					var stage = pipeline.stages[j];
-					for (var k = 0; k < stage.tasks.length; k++) {
-						task = stage.tasks[k];
-						if(task.hideTask) {
-							l.push(task);
+		if(!data.showHiddenTasks) {
+			for(var c = 0; c < data.pipelines.length; c++) {
+				component = data.pipelines[c];
+				for(var i=0; i< component.pipelines.length; i++) {
+					pipeline = component.pipelines[i];	
+					for (var j = 0; j < pipeline.stages.length; j++) {
+						var l = [];
+						var stage = pipeline.stages[j];
+						for (var k = 0; k < stage.tasks.length; k++) {
+							task = stage.tasks[k];
+							if(task.hideTask) {
+								l.push(task);
+							}
+						}
+						for(var m = 0; m < l.length; m++) {
+							stage.tasks.splice(Q.inArray(l[m], stage.tasks),1);
 						}
 					}
-					for(var m = 0; m < l.length; m++) {
-						stage.tasks.splice(Q.inArray(l[m], stage.tasks),1);
-					}
 				}
-			}
-		}	
+			}	
+		}
         for (var c = 0; c < data.pipelines.length; c++) {
             html = [];
             component = data.pipelines[c];

--- a/src/test/java/se/diabol/jenkins/pipeline/DeliveryPipelineViewTest.java
+++ b/src/test/java/se/diabol/jenkins/pipeline/DeliveryPipelineViewTest.java
@@ -368,7 +368,7 @@ public class DeliveryPipelineViewTest {
     @Test
     public void testGetPipelines() throws Exception {
         FreeStyleProject build = jenkins.createFreeStyleProject("build");
-        build.addProperty(new PipelineProperty("Build", "BuildStage", ""));
+        build.addProperty(new PipelineProperty("Build", "BuildStage", "", false));
         List<DeliveryPipelineView.ComponentSpec> specs = new ArrayList<DeliveryPipelineView.ComponentSpec>();
         specs.add(new DeliveryPipelineView.ComponentSpec("Comp", "build", NONE));
         DeliveryPipelineView view = new DeliveryPipelineView("Pipeline");
@@ -681,13 +681,13 @@ public class DeliveryPipelineViewTest {
     public void testRecursiveStages() throws Exception {
 
         FreeStyleProject a = jenkins.createFreeStyleProject("A");
-        a.addProperty(new PipelineProperty("A", "A", ""));
+        a.addProperty(new PipelineProperty("A", "A", "", false));
         FreeStyleProject b = jenkins.createFreeStyleProject("B");
-        b.addProperty(new PipelineProperty("B", "B", ""));
+        b.addProperty(new PipelineProperty("B", "B", "", false));
         FreeStyleProject c = jenkins.createFreeStyleProject("C");
-        c.addProperty(new PipelineProperty("C", "C", ""));
+        c.addProperty(new PipelineProperty("C", "C", "", false));
         FreeStyleProject d = jenkins.createFreeStyleProject("D");
-        d.addProperty(new PipelineProperty("D", "B", ""));
+        d.addProperty(new PipelineProperty("D", "B", "", false));
 
         a.getPublishersList().add(new hudson.plugins.parameterizedtrigger.BuildTrigger(new BuildTriggerConfig("B", ResultCondition.SUCCESS, new ArrayList<AbstractBuildParameterFactory>())));
         b.getPublishersList().add(new hudson.plugins.parameterizedtrigger.BuildTrigger(new BuildTriggerConfig("C", ResultCondition.SUCCESS, new ArrayList<AbstractBuildParameterFactory>())));

--- a/src/test/java/se/diabol/jenkins/pipeline/DeliveryPipelineViewTest.java
+++ b/src/test/java/se/diabol/jenkins/pipeline/DeliveryPipelineViewTest.java
@@ -236,7 +236,7 @@ public class DeliveryPipelineViewTest {
         assertTrue(view.isShowTestResults());
         view.setShowStaticAnalysisResults(true);
         assertTrue(view.isShowStaticAnalysisResults());
-		View.setShowHiddenTasks(true);
+		view.setShowHiddenTasks(true);
 		assertTrue(view.getShowHiddenTasks());
     }
 

--- a/src/test/java/se/diabol/jenkins/pipeline/DeliveryPipelineViewTest.java
+++ b/src/test/java/se/diabol/jenkins/pipeline/DeliveryPipelineViewTest.java
@@ -202,6 +202,7 @@ public class DeliveryPipelineViewTest {
         assertFalse(view.isShowPromotions());
         assertFalse(view.isShowTestResults());
         assertFalse(view.isShowStaticAnalysisResults());
+		assertFalse(view.getShowHiddenTasks());
     }
 
     @Test
@@ -235,6 +236,8 @@ public class DeliveryPipelineViewTest {
         assertTrue(view.isShowTestResults());
         view.setShowStaticAnalysisResults(true);
         assertTrue(view.isShowStaticAnalysisResults());
+		View.setShowHiddenTasks(true);
+		assertTrue(view.getShowHiddenTasks());
     }
 
     @Test

--- a/src/test/java/se/diabol/jenkins/pipeline/PipelinePropertyTest.java
+++ b/src/test/java/se/diabol/jenkins/pipeline/PipelinePropertyTest.java
@@ -140,7 +140,7 @@ public class PipelinePropertyTest {
         FreeStyleProject build2 = jenkins.createFreeStyleProject("build2");
         jenkins.createFreeStyleProject("build3");
         build2.addProperty(new PipelineProperty());
-        build.addProperty(new PipelineProperty("Build", "Build", ""));
+        build.addProperty(new PipelineProperty("Build", "Build", "", false));
 
 
         AutoCompletionCandidates c1 = d.doAutoCompleteStageName("B");
@@ -162,8 +162,8 @@ public class PipelinePropertyTest {
         Set<String> stageNames = PipelineProperty.getStageNames();
         assertNotNull(stageNames);
         assertEquals(0, stageNames.size());
-        build1.addProperty(new PipelineProperty(null, "Build", ""));
-        build2.addProperty(new PipelineProperty(null, "QA", ""));
+        build1.addProperty(new PipelineProperty(null, "Build", "", false));
+        build2.addProperty(new PipelineProperty(null, "QA", "", false));
 
         stageNames = PipelineProperty.getStageNames();
         assertNotNull(stageNames);

--- a/src/test/java/se/diabol/jenkins/pipeline/PipelinePropertyTest.java
+++ b/src/test/java/se/diabol/jenkins/pipeline/PipelinePropertyTest.java
@@ -82,7 +82,7 @@ public class PipelinePropertyTest {
         when(request.getParameter("stageName")).thenReturn("");
         when(request.getParameter("descriptionTemplate")).thenReturn("");
         when(request.getParameter("enabled")).thenReturn("on");
-        assertNull(d.newInstance(request, null));
+        assertNotNull(d.newInstance(request, null));
     }
 
     @Test
@@ -93,7 +93,7 @@ public class PipelinePropertyTest {
         when(request.getParameter("taskName")).thenReturn(null);
         when(request.getParameter("stageName")).thenReturn(null);
         when(request.getParameter("enabled")).thenReturn("on");
-        assertNull(d.newInstance(request, null));
+        assertNotNull(d.newInstance(request, null));
     }
 
     @Test

--- a/src/test/java/se/diabol/jenkins/pipeline/domain/PipelineTest.java
+++ b/src/test/java/se/diabol/jenkins/pipeline/domain/PipelineTest.java
@@ -819,7 +819,7 @@ public class PipelineTest {
     }
     
     @Test
-    public void testPipelineWithHiddenTasksRecursively() throws Exception {
+    public void testPipelineWithHiddenTasks() throws Exception {
     	 /* actual with out hidden
         stage1   stage2   stage3   stage4
         task1 -- task2 -- task4 -- task6
@@ -861,15 +861,33 @@ public class PipelineTest {
         task6.getPublishersList().add(new hudson.plugins.parameterizedtrigger.BuildTrigger(new BuildTriggerConfig("task7", ResultCondition.SUCCESS, new ArrayList<AbstractBuildParameterFactory>())));
         
         jenkins.getInstance().rebuildDependencyGraph();
-
-        try {
-            Pipeline.extractPipeline("Test", task1);
-            fail();
-        } catch (StackOverflowError e) {
-            fail("Should not throw StackOverflowError");
-        } catch (PipelineException e) {
-            //Should throw this
-        }
+        
+    	Pipeline pipeline = Pipeline.extractPipeline("TestHidden", task1);
+    	
+    	assertNotNull(pipeline);
+        assertEquals("TestHidden", pipeline.getName());
+        assertEquals(4, pipeline.getStages().size());
+        
+        Stage stage1 = pipeline.getStages().get(0);
+        assertEquals("stage1", stage1.getName());
+        assertEquals(1, stage1.getTasks().size());
+        assertEquals("task1", stage1.getTasks().get(0).getName());
+        
+        Stage stage2 = pipeline.getStages().get(1);
+        assertEquals("stage2", stage2.getName());
+        assertEquals(1, stage2.getTasks().size());
+        assertEquals("task3", stage2.getTasks().get(0).getName());
+        
+        Stage stage3 = pipeline.getStages().get(2);
+        assertEquals("stage3", stage3.getName());
+        assertEquals(2, stage3.getTasks().size());
+        assertEquals("task4", stage3.getTasks().get(0).getName());
+        assertEquals("task5", stage3.getTasks().get(1).getName());
+        
+        Stage stage4 = pipeline.getStages().get(3);
+        assertEquals("stage4", stage4.getName());
+        assertEquals(1, stage4.getTasks().size());
+        assertEquals("task7", stage4.getTasks().get(0).getName());
     }
 
 }

--- a/src/test/java/se/diabol/jenkins/pipeline/domain/PipelineTest.java
+++ b/src/test/java/se/diabol/jenkins/pipeline/domain/PipelineTest.java
@@ -71,7 +71,7 @@ public class PipelineTest {
         assertEquals("job", pipeline.getStages().get(0).getName());
         assertEquals("job", pipeline.getStages().get(0).getTasks().get(0).getName());
 
-        job.addProperty(new PipelineProperty("", "", ""));
+        job.addProperty(new PipelineProperty("", "", "", false));
 
         pipeline = Pipeline.extractPipeline("Pipeline", job);
         assertEquals(1, pipeline.getStages().size());
@@ -86,12 +86,12 @@ public class PipelineTest {
         FreeStyleProject deploy = jenkins.createFreeStyleProject("deploy");
         FreeStyleProject test = jenkins.createFreeStyleProject("test");
 
-        compile.addProperty(new PipelineProperty("Compile", "Build", ""));
+        compile.addProperty(new PipelineProperty("Compile", "Build", "", false));
         compile.save();
 
-        deploy.addProperty(new PipelineProperty("Deploy", "Deploy", ""));
+        deploy.addProperty(new PipelineProperty("Deploy", "Deploy", "", false));
         deploy.save();
-        test.addProperty(new PipelineProperty("Test", "Test", ""));
+        test.addProperty(new PipelineProperty("Test", "Test", "", false));
         test.save();
 
         compile.getPublishersList().add(new BuildTrigger("test", false));
@@ -129,13 +129,13 @@ public class PipelineTest {
     @Test
     public void testExtractSimpleForkJoinPipeline() throws Exception {
         FreeStyleProject build = jenkins.createFreeStyleProject("build");
-        build.addProperty(new PipelineProperty(null, "build", ""));
+        build.addProperty(new PipelineProperty(null, "build", "", false));
         FreeStyleProject deploy1 = jenkins.createFreeStyleProject("deploy1");
-        deploy1.addProperty(new PipelineProperty(null, "CI", ""));
+        deploy1.addProperty(new PipelineProperty(null, "CI", "", false));
         FreeStyleProject deploy2 = jenkins.createFreeStyleProject("deploy2");
-        deploy2.addProperty(new PipelineProperty(null, "CI", ""));
+        deploy2.addProperty(new PipelineProperty(null, "CI", "", false));
         FreeStyleProject deploy3 = jenkins.createFreeStyleProject("deploy3");
-        deploy3.addProperty(new PipelineProperty(null, "QA", ""));
+        deploy3.addProperty(new PipelineProperty(null, "QA", "", false));
 
         build.getPublishersList().add(new BuildTrigger("deploy1,deploy2", false));
         deploy1.getPublishersList().add(new BuildTrigger("deploy3", false));
@@ -154,12 +154,12 @@ public class PipelineTest {
     @Test
     public void testExtractPipelineWithSubProjects() throws Exception {
         FreeStyleProject build = jenkins.createFreeStyleProject("build");
-        build.addProperty(new PipelineProperty("Build", "Build", ""));
+        build.addProperty(new PipelineProperty("Build", "Build", "", false));
         FreeStyleProject sonar = jenkins.createFreeStyleProject("sonar");
-        sonar.addProperty(new PipelineProperty("Sonar", "Build", ""));
+        sonar.addProperty(new PipelineProperty("Sonar", "Build", "", false));
 
         FreeStyleProject deploy = jenkins.createFreeStyleProject("deploy");
-        deploy.addProperty(new PipelineProperty("Deploy", "QA", ""));
+        deploy.addProperty(new PipelineProperty("Deploy", "QA", "", false));
 
 
         build.getBuildersList().add(new TriggerBuilder(new BlockableBuildTriggerConfig("sonar", new BlockingBehaviour("never", "never", "never"), null)));
@@ -282,8 +282,8 @@ public class PipelineTest {
         FreeStyleProject build = jenkins.createFreeStyleProject("build");
         FreeStyleProject ci1 = jenkins.createFreeStyleProject("ci1");
         FreeStyleProject ci2 = jenkins.createFreeStyleProject("ci2");
-        ci1.addProperty(new PipelineProperty("ci1", "CI1", ""));
-        ci2.addProperty(new PipelineProperty("ci2", "CI1", ""));
+        ci1.addProperty(new PipelineProperty("ci1", "CI1", "", false));
+        ci2.addProperty(new PipelineProperty("ci2", "CI1", "", false));
         build.getPublishersList().add(new BuildPipelineTrigger("ci1", null));
         build.getPublishersList().add(new BuildPipelineTrigger("ci2", null));
         jenkins.getInstance().rebuildDependencyGraph();
@@ -332,11 +332,11 @@ public class PipelineTest {
     @Test
     public void testCreatePipelineLatest() throws Exception {
         FreeStyleProject build = jenkins.createFreeStyleProject("build");
-        build.addProperty(new PipelineProperty("", "Build", ""));
+        build.addProperty(new PipelineProperty("", "Build", "", false));
         FreeStyleProject sonar = jenkins.createFreeStyleProject("sonar");
-        sonar.addProperty(new PipelineProperty("Sonar", "Build", ""));
+        sonar.addProperty(new PipelineProperty("Sonar", "Build", "", false));
         FreeStyleProject deploy = jenkins.createFreeStyleProject("deploy");
-        deploy.addProperty(new PipelineProperty("Deploy", "CI", ""));
+        deploy.addProperty(new PipelineProperty("Deploy", "CI", "", false));
         jenkins.getInstance().rebuildDependencyGraph();
         jenkins.setQuietPeriod(0);
 
@@ -671,13 +671,13 @@ public class PipelineTest {
     public void testRecursiveStages() throws Exception {
 
         FreeStyleProject a = jenkins.createFreeStyleProject("A");
-        a.addProperty(new PipelineProperty("A", "A", ""));
+        a.addProperty(new PipelineProperty("A", "A", "", false));
         FreeStyleProject b = jenkins.createFreeStyleProject("B");
-        b.addProperty(new PipelineProperty("B", "B", ""));
+        b.addProperty(new PipelineProperty("B", "B", "", false));
         FreeStyleProject c = jenkins.createFreeStyleProject("C");
-        c.addProperty(new PipelineProperty("C", "C", ""));
+        c.addProperty(new PipelineProperty("C", "C", "", false));
         FreeStyleProject d = jenkins.createFreeStyleProject("D");
-        d.addProperty(new PipelineProperty("D", "B", ""));
+        d.addProperty(new PipelineProperty("D", "B", "", false));
 
         a.getPublishersList().add(new hudson.plugins.parameterizedtrigger.BuildTrigger(new BuildTriggerConfig("B", ResultCondition.SUCCESS, new ArrayList<AbstractBuildParameterFactory>())));
         b.getPublishersList().add(new hudson.plugins.parameterizedtrigger.BuildTrigger(new BuildTriggerConfig("C", ResultCondition.SUCCESS, new ArrayList<AbstractBuildParameterFactory>())));

--- a/src/test/java/se/diabol/jenkins/pipeline/domain/PipelineTest.java
+++ b/src/test/java/se/diabol/jenkins/pipeline/domain/PipelineTest.java
@@ -894,13 +894,13 @@ public class PipelineTest {
     @Bug(30043)
     public void testSubProjectsFirst() throws Exception {
         FreeStyleProject jobA = jenkins.createFreeStyleProject("Job A");
-        jobA.addProperty(new PipelineProperty(null, "Stage", null));
+        jobA.addProperty(new PipelineProperty(null, "Stage", null, false));
         FreeStyleProject util1 = jenkins.createFreeStyleProject("Job Util 1");
-        util1.addProperty(new PipelineProperty(null, "Stage", null));
+        util1.addProperty(new PipelineProperty(null, "Stage", null, false));
         FreeStyleProject util2 = jenkins.createFreeStyleProject("Job Util 2");
-        util2.addProperty(new PipelineProperty(null, "Stage", null));
+        util2.addProperty(new PipelineProperty(null, "Stage", null, false));
         FreeStyleProject jobC = jenkins.createFreeStyleProject("Job C");
-        jobC.addProperty(new PipelineProperty(null, "Stage", null));
+        jobC.addProperty(new PipelineProperty(null, "Stage", null, false));
 
         jobA.getBuildersList().add(new TriggerBuilder(new BlockableBuildTriggerConfig("Job Util 1", new BlockingBehaviour("never", "never", "never"), null)));
         jobA.getBuildersList().add(new TriggerBuilder(new BlockableBuildTriggerConfig("Job Util 2", new BlockingBehaviour("never", "never", "never"), null)));
@@ -908,7 +908,7 @@ public class PipelineTest {
 
         jenkins.getInstance().rebuildDependencyGraph();
 
-        Pipeline pipeline = Pipeline.extractPipeline("Pipeline", jobA);
+        Pipeline pipeline = Pipeline.extractPipeline("Pipeline", jobA, false);
 
         assertEquals("Job A", pipeline.getStages().get(0).getTasks().get(0).getId());
         assertEquals("Job Util 1", pipeline.getStages().get(0).getTasks().get(1).getId());

--- a/src/test/java/se/diabol/jenkins/pipeline/domain/PipelineTest.java
+++ b/src/test/java/se/diabol/jenkins/pipeline/domain/PipelineTest.java
@@ -66,14 +66,14 @@ public class PipelineTest {
     public void testExtractPipelineEmptyPropertyAndNullProperty() throws Exception {
         FreeStyleProject job = jenkins.createFreeStyleProject("job");
 
-        Pipeline pipeline = Pipeline.extractPipeline("Pipeline", job);
+        Pipeline pipeline = Pipeline.extractPipeline("Pipeline", job, false);
         assertEquals(1, pipeline.getStages().size());
         assertEquals("job", pipeline.getStages().get(0).getName());
         assertEquals("job", pipeline.getStages().get(0).getTasks().get(0).getName());
 
         job.addProperty(new PipelineProperty("", "", "", false));
 
-        pipeline = Pipeline.extractPipeline("Pipeline", job);
+        pipeline = Pipeline.extractPipeline("Pipeline", job, false);
         assertEquals(1, pipeline.getStages().size());
         assertEquals("job", pipeline.getStages().get(0).getName());
         assertEquals("job", pipeline.getStages().get(0).getTasks().get(0).getName());
@@ -100,7 +100,7 @@ public class PipelineTest {
         jenkins.getInstance().rebuildDependencyGraph();
 
 
-        Pipeline pipeline = Pipeline.extractPipeline("Piper", compile);
+        Pipeline pipeline = Pipeline.extractPipeline("Piper", compile, false);
 
         assertNotNull(pipeline);
         assertEquals("Piper", pipeline.getName());
@@ -143,7 +143,7 @@ public class PipelineTest {
 
         jenkins.getInstance().rebuildDependencyGraph();
 
-        Pipeline pipeline = Pipeline.extractPipeline("Pipeline", build);
+        Pipeline pipeline = Pipeline.extractPipeline("Pipeline", build, false);
 
         assertEquals(3, pipeline.getStages().size());
         assertEquals(1, pipeline.getStages().get(2).getTasks().size());
@@ -167,7 +167,7 @@ public class PipelineTest {
 
         jenkins.getInstance().rebuildDependencyGraph();
 
-        Pipeline pipeline = Pipeline.extractPipeline("Pipeline", build);
+        Pipeline pipeline = Pipeline.extractPipeline("Pipeline", build, false);
         assertEquals(2, pipeline.getStages().size());
         assertEquals(2, pipeline.getStages().get(0).getTasks().size());
         assertEquals(1, pipeline.getStages().get(1).getTasks().size());
@@ -188,8 +188,8 @@ public class PipelineTest {
 
         jenkins.getInstance().rebuildDependencyGraph();
         jenkins.setQuietPeriod(0);
-        final Pipeline pipe1 = Pipeline.extractPipeline("pipe1", build1);
-        final Pipeline pipe2 = Pipeline.extractPipeline("pipe2", build2);
+        final Pipeline pipe1 = Pipeline.extractPipeline("pipe1", build1, false);
+        final Pipeline pipe2 = Pipeline.extractPipeline("pipe2", build2, false);
 
         Pipeline aggregated1 = pipe1.createPipelineAggregated(jenkins.getInstance());
         Pipeline aggregated2 = pipe2.createPipelineAggregated(jenkins.getInstance());
@@ -300,7 +300,7 @@ public class PipelineTest {
         assertNotNull(ci1.getLastBuild());
         assertNull(ci2.getLastBuild());
 
-        Pipeline pipeline = Pipeline.extractPipeline("test", build);
+        Pipeline pipeline = Pipeline.extractPipeline("test", build, false);
         Pipeline aggregated = pipeline.createPipelineAggregated(jenkins.getInstance());
         assertNotNull(aggregated);
         assertEquals("ci1", aggregated.getStages().get(1).getTasks().get(0).getName());
@@ -340,7 +340,7 @@ public class PipelineTest {
         jenkins.getInstance().rebuildDependencyGraph();
         jenkins.setQuietPeriod(0);
 
-        Pipeline pipeline = Pipeline.extractPipeline("Pipeline", build);
+        Pipeline pipeline = Pipeline.extractPipeline("Pipeline", build, false);
         assertNotNull(pipeline);
         assertEquals("Pipeline", pipeline.getName());
         assertEquals(1, pipeline.getStages().size());
@@ -353,7 +353,7 @@ public class PipelineTest {
         build.getPublishersList().add(new BuildTrigger("sonar,deploy", false));
         jenkins.getInstance().rebuildDependencyGraph();
 
-        pipeline = Pipeline.extractPipeline("Pipeline", build);
+        pipeline = Pipeline.extractPipeline("Pipeline", build, false);
 
         buildStage = pipeline.getStages().get(0);
         assertEquals("Build", buildStage.getName());
@@ -393,7 +393,7 @@ public class PipelineTest {
         jenkins.getInstance().rebuildDependencyGraph();
         jenkins.buildAndAssertSuccess(build);
         jenkins.waitUntilNoActivity();
-        Pipeline pipeline = Pipeline.extractPipeline("Pipeline", build);
+        Pipeline pipeline = Pipeline.extractPipeline("Pipeline", build, false);
         Pipeline latest = createPipelineLatest(pipeline, jenkins.getInstance());
         assertNotNull(latest);
         assertEquals(2, latest.getStages().size());
@@ -417,7 +417,7 @@ public class PipelineTest {
         assertNotNull(build.getLastBuild());
 
         assertEquals(build.getLastBuild(), BuildUtil.getFirstUpstreamBuild(build.getLastBuild(), build));
-        Pipeline pipeline = Pipeline.extractPipeline("Pipeline", build);
+        Pipeline pipeline = Pipeline.extractPipeline("Pipeline", build, false);
         List<Pipeline> pipelines = pipeline.createPipelineLatest(1, Jenkins.getInstance());
         assertEquals(1, pipelines.size());
         assertEquals(1, pipelines.get(0).getTriggeredBy().size());
@@ -437,7 +437,7 @@ public class PipelineTest {
         jenkins.getInstance().rebuildDependencyGraph();
         jenkins.setQuietPeriod(0);
 
-        Pipeline prototype = Pipeline.extractPipeline("Folders", job1);
+        Pipeline prototype = Pipeline.extractPipeline("Folders", job1, false);
 
         assertNotNull(prototype);
 
@@ -469,7 +469,7 @@ public class PipelineTest {
         c.getPublishersList().add(new BuildTrigger("D", false));
         d.getPublishersList().add(new JoinTrigger(new DescribableList<Publisher, Descriptor<Publisher>>(Saveable.NOOP), "", false));
         jenkins.getInstance().rebuildDependencyGraph();
-        Pipeline prototype = Pipeline.extractPipeline("ForkJoin", a);
+        Pipeline prototype = Pipeline.extractPipeline("ForkJoin", a, false);
         assertNotNull(prototype);
         assertEquals(4, prototype.getStages().size());
 
@@ -494,7 +494,7 @@ public class PipelineTest {
         jenkins.getInstance().rebuildDependencyGraph();
         jenkins.setQuietPeriod(0);
 
-        Pipeline prototype = Pipeline.extractPipeline("Folders", job1);
+        Pipeline prototype = Pipeline.extractPipeline("Folders", job1, false);
 
         assertNotNull(prototype);
 
@@ -528,7 +528,7 @@ public class PipelineTest {
         jenkins.getInstance().rebuildDependencyGraph();
         jenkins.setQuietPeriod(0);
 
-        Pipeline prototype = Pipeline.extractPipeline("Folders", job1);
+        Pipeline prototype = Pipeline.extractPipeline("Folders", job1, false);
 
         assertNotNull(prototype);
 
@@ -572,7 +572,7 @@ public class PipelineTest {
         jenkins.getInstance().rebuildDependencyGraph();
         jenkins.setQuietPeriod(0);
 
-        Pipeline pipeline = Pipeline.extractPipeline("test", a);
+        Pipeline pipeline = Pipeline.extractPipeline("test", a, false);
 
         assertEquals("a", pipeline.getStages().get(0).getName());
         assertEquals(0, pipeline.getStages().get(0).getRow());
@@ -624,7 +624,7 @@ public class PipelineTest {
         jenkins.getInstance().rebuildDependencyGraph();
         jenkins.setQuietPeriod(0);
 
-        Pipeline pipeline = Pipeline.extractPipeline("test", a);
+        Pipeline pipeline = Pipeline.extractPipeline("test", a, false);
 
         assertEquals("a", pipeline.getStages().get(0).getName());
         assertEquals(0, pipeline.getStages().get(0).getRow());
@@ -686,7 +686,7 @@ public class PipelineTest {
         jenkins.getInstance().rebuildDependencyGraph();
 
         try {
-            Pipeline.extractPipeline("Test", a);
+            Pipeline.extractPipeline("Test", a, false);
             fail();
         } catch (StackOverflowError e) {
             fail("Should not throw StackOverflowError");
@@ -699,7 +699,7 @@ public class PipelineTest {
     @Test
     public void testShouldShowPipelineInstanceInQueue() throws Exception {
         FreeStyleProject a = jenkins.createFreeStyleProject("A");
-        Pipeline prototype = Pipeline.extractPipeline("Pipe", a);
+        Pipeline prototype = Pipeline.extractPipeline("Pipe", a, false);
         a.scheduleBuild(2, new Cause.UserIdCause());
         List<Pipeline> pipelines = prototype.createPipelineLatest(5, Jenkins.getInstance());
         assertEquals(1, pipelines.size());
@@ -862,7 +862,7 @@ public class PipelineTest {
         
         jenkins.getInstance().rebuildDependencyGraph();
         
-    	Pipeline pipeline = Pipeline.extractPipeline("TestHidden", task1);
+    	Pipeline pipeline = Pipeline.extractPipeline("TestHidden", task1, false);
     	
     	assertNotNull(pipeline);
         assertEquals("TestHidden", pipeline.getName());

--- a/src/test/java/se/diabol/jenkins/pipeline/domain/StageTest.java
+++ b/src/test/java/se/diabol/jenkins/pipeline/domain/StageTest.java
@@ -199,7 +199,7 @@ public class StageTest {
         Collection<MatrixConfiguration> configurations = project.getActiveConfigurations();
 
         for (MatrixConfiguration configuration : configurations) {
-            List<Stage> stages = Stage.extractStages(configuration, null);
+            List<Stage> stages = Stage.extractStages(configuration, null, false);
             assertEquals(1, stages.size());
             Stage stage = stages.get(0);
             assertEquals("stage", stage.getName());

--- a/src/test/java/se/diabol/jenkins/pipeline/domain/StageTest.java
+++ b/src/test/java/se/diabol/jenkins/pipeline/domain/StageTest.java
@@ -183,7 +183,7 @@ public class StageTest {
     @Test
     @WithoutJenkins
     public void testFindStageForJob() {
-        Task task1 = new Task(null, "build", "Build", StatusFactory.idle(), null, null, Collections.<String>emptyList(), true, "description");
+        Task task1 = new Task(null, "build", "Build", StatusFactory.idle(), null, null, Collections.<String>emptyList(), true, "description", false);
         List<Stage> stages = Lists.newArrayList(new Stage("QA", Lists.newArrayList(task1)));
         assertNull(Stage.findStageForJob("nofind", stages));
         assertNotNull(Stage.findStageForJob("build", stages));
@@ -194,7 +194,7 @@ public class StageTest {
     public void testStageNameForMultiConfiguration() throws Exception {
         MatrixProject project = jenkins.createMatrixProject("Multi");
         project.setAxes(new AxisList(new Axis("axis", "foo", "bar")));
-        project.addProperty(new PipelineProperty("task", "stage", ""));
+        project.addProperty(new PipelineProperty("task", "stage", "", false));
 
         Collection<MatrixConfiguration> configurations = project.getActiveConfigurations();
 

--- a/src/test/java/se/diabol/jenkins/pipeline/domain/status/SimpleStatusTest.java
+++ b/src/test/java/se/diabol/jenkins/pipeline/domain/status/SimpleStatusTest.java
@@ -348,7 +348,7 @@ public class SimpleStatusTest {
         project1.getPublishersList().add(new BuildPipelineTrigger("project2", null));
 
         jenkins.getInstance().rebuildDependencyGraph();
-        Pipeline pipeline = Pipeline.extractPipeline("name", project1);
+        Pipeline pipeline = Pipeline.extractPipeline("name", project1, false);
         jenkins.buildAndAssertSuccess(project1);
         jenkins.buildAndAssertSuccess(project1);
         jenkins.waitUntilNoActivity();

--- a/src/test/java/se/diabol/jenkins/pipeline/domain/task/TaskTest.java
+++ b/src/test/java/se/diabol/jenkins/pipeline/domain/task/TaskTest.java
@@ -65,7 +65,7 @@ public class TaskTest {
         FreeStyleProject project = jenkins.createFreeStyleProject("test");
         jenkins.getInstance().setQuietPeriod(0);
 
-        Task task = Task.getPrototypeTask(project, true);
+        Task task = Task.getPrototypeTask(project, true, false);
         assertNotNull(task);
         assertFalse(task.isManual());
         assertFalse(task.isRebuildable());
@@ -92,7 +92,7 @@ public class TaskTest {
         a.getPublishersList().add(new BuildPipelineTrigger("b", null));
         jenkins.getInstance().rebuildDependencyGraph();
 
-        Task task = Task.getPrototypeTask(b, false);
+        Task task = Task.getPrototypeTask(b, false, false);
         assertTrue(task.isManual());
 
     }
@@ -113,7 +113,7 @@ public class TaskTest {
                 return true;
             }
         });
-        Task prototype = Task.getPrototypeTask(project, true);
+        Task prototype = Task.getPrototypeTask(project, true, false);
 
         project.scheduleBuild2(0);
         buildStarted.block(); // wait for the build to really start
@@ -143,7 +143,7 @@ public class TaskTest {
         Collection<MatrixConfiguration> configurations = project.getActiveConfigurations();
 
         for (MatrixConfiguration configuration : configurations) {
-            Task task = Task.getPrototypeTask(configuration, true);
+            Task task = Task.getPrototypeTask(configuration, true, false);
             assertEquals("task "  + configuration.getName(), task.getName());
 
         }
@@ -158,7 +158,7 @@ public class TaskTest {
         a.getPublishersList().add(new BuildPipelineTrigger("b", null));
         b.getBuildersList().add(new FailureBuilder());
         FreeStyleBuild build = jenkins.buildAndAssertSuccess(a);
-        Task task = Task.getPrototypeTask(b, false);
+        Task task = Task.getPrototypeTask(b, false, false);
         assertTrue(task.getLatestTask(jenkins.getInstance(), build).getStatus().isIdle());
 
         DeliveryPipelineView view = new DeliveryPipelineView("Pipeline", jenkins.getInstance());
@@ -177,7 +177,7 @@ public class TaskTest {
     public void testIsRebuildable() throws Exception {
         jenkins.setQuietPeriod(0);
         FreeStyleProject project = jenkins.createFreeStyleProject("project");
-        Task task = Task.getPrototypeTask(project, false);
+        Task task = Task.getPrototypeTask(project, false, false);
         //IDLE
         assertFalse(task.getLatestTask(jenkins.getInstance(), null).isRebuildable());
         //FAILED
@@ -214,7 +214,7 @@ public class TaskTest {
 
         SecurityContext oldContext = ACL.impersonate(User.get("devel").impersonate());
 
-        Task prototype  = Task.getPrototypeTask(b, false);
+        Task prototype  = Task.getPrototypeTask(b, false, false);
         Task task = prototype.getLatestTask(jenkins.getInstance(), firstBuild);
         assertNotNull(task);
         assertFalse(task.isRebuildable());
@@ -253,8 +253,8 @@ public class TaskTest {
         jenkins.setQuietPeriod(0);
         jenkins.getInstance().rebuildDependencyGraph();
 
-        Task taskA = Task.getPrototypeTask(a, true).getLatestTask(jenkins.getInstance(), null);
-        Task taskB = Task.getPrototypeTask(b, false).getLatestTask(jenkins.getInstance(), null);
+        Task taskA = Task.getPrototypeTask(a, true, false).getLatestTask(jenkins.getInstance(), null);
+        Task taskB = Task.getPrototypeTask(b, false, false).getLatestTask(jenkins.getInstance(), null);
 
         assertEquals(expectedBeforeA, taskA.getName());
         assertEquals(expectedBeforeB, taskB.getName());
@@ -262,8 +262,8 @@ public class TaskTest {
         FreeStyleBuild firstBuild = jenkins.buildAndAssertSuccess(a);
         jenkins.waitUntilNoActivity();
 
-        taskA = Task.getPrototypeTask(a, true).getLatestTask(jenkins.getInstance(), firstBuild);
-        taskB = Task.getPrototypeTask(b, false).getLatestTask(jenkins.getInstance(), firstBuild);
+        taskA = Task.getPrototypeTask(a, true, false).getLatestTask(jenkins.getInstance(), firstBuild);
+        taskB = Task.getPrototypeTask(b, false, false).getLatestTask(jenkins.getInstance(), firstBuild);
 
         assertEquals(expectedAfterA, taskA.getName());
         assertEquals(expectedAfterB, taskB.getName());

--- a/src/test/java/se/diabol/jenkins/pipeline/domain/task/TaskTest.java
+++ b/src/test/java/se/diabol/jenkins/pipeline/domain/task/TaskTest.java
@@ -138,7 +138,7 @@ public class TaskTest {
     public void testTaskNameForMultiConfiguration() throws Exception {
         MatrixProject project = jenkins.createMatrixProject("Multi");
         project.setAxes(new AxisList(new Axis("axis", "foo", "bar")));
-        project.addProperty(new PipelineProperty("task", "stage", ""));
+        project.addProperty(new PipelineProperty("task", "stage", "", false));
 
         Collection<MatrixConfiguration> configurations = project.getActiveConfigurations();
 
@@ -246,8 +246,8 @@ public class TaskTest {
             throws Exception {
         FreeStyleProject a = jenkins.createFreeStyleProject("A");
         FreeStyleProject b = jenkins.createFreeStyleProject("B");
-        a.addProperty(new PipelineProperty(taskNameA, "Stage Build", null));
-        b.addProperty(new PipelineProperty(taskNameB, "Stage Deploy", null));
+        a.addProperty(new PipelineProperty(taskNameA, "Stage Build", null, false));
+        b.addProperty(new PipelineProperty(taskNameB, "Stage Deploy", null, false));
 
         a.getPublishersList().add(new BuildTrigger("B", false));
         jenkins.setQuietPeriod(0);

--- a/src/test/java/se/diabol/jenkins/pipeline/sort/LatestActivityComparatorTest.java
+++ b/src/test/java/se/diabol/jenkins/pipeline/sort/LatestActivityComparatorTest.java
@@ -37,7 +37,7 @@ public class LatestActivityComparatorTest {
     @Test
     public void testCompare() {
         Task taskA = new Task(null, "task", "Build", StatusFactory.success(0, 20, false,
-                Collections.<PromotionStatus>emptyList()), null, null, null, true, "");
+                Collections.<PromotionStatus>emptyList()), null, null, null, true, "", false);
 
         List<Task> tasksA = new ArrayList<Task>();
         tasksA.add(taskA);
@@ -49,7 +49,7 @@ public class LatestActivityComparatorTest {
         pipelinesA.add(pipelineA);
 
         Task taskB = new Task(null, "task", "Build", StatusFactory.success(10, 20, false,
-                Collections.<PromotionStatus>emptyList()), null, null, null, true, "");
+                Collections.<PromotionStatus>emptyList()), null, null, null, true, "", false);
 
         List<Task> tasksB = new ArrayList<Task>();
         tasksB.add(taskB);


### PR DESCRIPTION
When configuring upstream and downstream jobs, required some jobs to create which are going to handle certain background functionality which are not required in pipeline to visible.

This will work best with when we configure Stages and Tasks. Provided check box to every Job configuration of Delivery Pipeline Configuration whether to show/hide in pipeline.

Example:
**View Before**
![before](https://cloud.githubusercontent.com/assets/8586903/13198077/3ead44e0-d825-11e5-90b5-f0c9a14f05f6.PNG)

**View After**
![after](https://cloud.githubusercontent.com/assets/8586903/13198078/4bdab454-d825-11e5-842d-a625b1567ffe.PNG)

