### PR TITLE
Fix JENKINS-33594: Rebuilding broken in Jenkins ver. 1.653

### DIFF
--- a/src/main/java/se/diabol/jenkins/pipeline/DeliveryPipelineView.java
+++ b/src/main/java/se/diabol/jenkins/pipeline/DeliveryPipelineView.java
@@ -381,13 +381,14 @@ public class DeliveryPipelineView extends View {
 
         @SuppressWarnings("unchecked")
         List<Cause> prevCauses = build.getCauses();
-        CauseAction causeAction = new CauseAction();
+        List<Cause> newCauses = new ArrayList<Cause>();
         for (Cause cause : prevCauses) {
             if (!(cause instanceof Cause.UserIdCause)) {
-                causeAction.getCauses().add(cause);
+                newCauses.add(cause);
             }
         }
-        causeAction.getCauses().add(new Cause.UserIdCause());
+        newCauses.add(new Cause.UserIdCause());
+        CauseAction causeAction = new CauseAction(newCauses);
         project.scheduleBuild2(project.getQuietPeriod(),null, causeAction, build.getAction(ParametersAction.class));
     }
 


### PR DESCRIPTION
The cause list is immutable as described in the comments of
[JENKINS-33467](https://issues.jenkins-ci.org/browse/JENKINS-33467).