### PR TITLE
JENKINS-34196 Modified getItems() method to only return jobs from pipeline view

### DIFF
--- a/src/main/java/se/diabol/jenkins/pipeline/DeliveryPipelineView.java
+++ b/src/main/java/se/diabol/jenkins/pipeline/DeliveryPipelineView.java
@@ -17,6 +17,7 @@ If not, see <http://www.gnu.org/licenses/>.
 */
 package se.diabol.jenkins.pipeline;
 
+import com.google.common.collect.Sets;
 import hudson.DescriptorExtensionList;
 import hudson.Extension;
 import hudson.model.AbstractDescribableImpl;
@@ -44,6 +45,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
@@ -75,6 +77,10 @@ import se.diabol.jenkins.pipeline.trigger.TriggerException;
 import se.diabol.jenkins.pipeline.util.JenkinsUtil;
 import se.diabol.jenkins.pipeline.util.PipelineUtils;
 import se.diabol.jenkins.pipeline.util.ProjectUtil;
+
+import static se.diabol.jenkins.pipeline.util.ProjectUtil.getAllDownstreamProjects;
+import static se.diabol.jenkins.pipeline.util.ProjectUtil.getProject;
+import static se.diabol.jenkins.pipeline.util.ProjectUtil.getProjects;
 
 public class DeliveryPipelineView extends View {
 
@@ -513,7 +519,36 @@ public class DeliveryPipelineView extends View {
 
     @Override
     public Collection<TopLevelItem> getItems() {
-        return (Collection)getOwnerItemGroup().getItems();
+        Set<TopLevelItem> jobs = Sets.newHashSet();
+        addJobsFromComponentSpecs(jobs);
+        addRegexpFirstJobs(jobs);
+        return jobs;
+    }
+
+    private void addJobsFromComponentSpecs(Set<TopLevelItem> jobs) {
+        if (componentSpecs == null) {
+            return;
+        }
+        for (ComponentSpec spec : componentSpecs) {
+            AbstractProject first = getProject(spec.getFirstJob(), getOwnerItemGroup());
+            AbstractProject last = getProject(spec.getLastJob(), getOwnerItemGroup());
+            Collection<AbstractProject<?, ?>> downstreamProjects = getAllDownstreamProjects(first, last).values();
+            for (AbstractProject project : downstreamProjects) {
+                jobs.add((TopLevelItem) project);
+            }
+        }
+    }
+
+    private void addRegexpFirstJobs(Set<TopLevelItem> jobs) {
+        if (regexpFirstJobs == null) {
+            return;
+        }
+        for (RegExpSpec spec : regexpFirstJobs) {
+            Map<String, AbstractProject> regexpJobs = getProjects(spec.getRegexp());
+            for (AbstractProject project : regexpJobs.values()) {
+                jobs.add((TopLevelItem) project);
+            }
+        }
     }
 
     @Override

--- a/src/test/java/se/diabol/jenkins/pipeline/DeliveryPipelineViewTest.java
+++ b/src/test/java/se/diabol/jenkins/pipeline/DeliveryPipelineViewTest.java
@@ -45,6 +45,7 @@ import hudson.tasks.BuildTrigger;
 import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
 
+import java.io.IOException;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -572,7 +573,7 @@ public class DeliveryPipelineViewTest {
         assertTrue(names.contains("Project2"));
         assertTrue(names.contains("Project3"));
 
-        assertEquals(4, view.getItems().size());
+        assertEquals(3, view.getItems().size());
     }
 
     @Test
@@ -833,6 +834,27 @@ public class DeliveryPipelineViewTest {
     public void testComponentSpecDescriptorImpldoFillFirstJobItems() throws Exception {
         jenkins.createFreeStyleProject("a");
         assertEquals(1, new DeliveryPipelineView.ComponentSpec.DescriptorImpl().doFillFirstJobItems(jenkins.getInstance()).size());
+    }
+
+    @Test
+    public void testGetItems() throws IOException {
+        FreeStyleProject firstJob = jenkins.createFreeStyleProject("Project1");
+        FreeStyleProject secondJob = jenkins.createFreeStyleProject("Project2");
+        FreeStyleProject thirdJob = jenkins.createFreeStyleProject("Project3");
+
+        firstJob.getPublishersList().add((new BuildTrigger(secondJob.getName(), true)));
+        jenkins.getInstance().rebuildDependencyGraph();
+
+        DeliveryPipelineView pipeline = new DeliveryPipelineView("Pipeline");
+        List<DeliveryPipelineView.ComponentSpec> componentSpecs = new ArrayList<DeliveryPipelineView.ComponentSpec>();
+        componentSpecs.add(new DeliveryPipelineView.ComponentSpec("Spec", firstJob.getName(), NONE));
+        pipeline.setComponentSpecs(componentSpecs);
+        jenkins.getInstance().addView(pipeline);
+
+        Collection<TopLevelItem> jobs = pipeline.getItems();
+        assertTrue(jobs.contains(firstJob));
+        assertTrue(jobs.contains(secondJob));
+        assertFalse(jobs.contains(thirdJob));
     }
 
     private void assertEqualsList(List<ParametersAction> a1, List<ParametersAction> a2) {


### PR DESCRIPTION
In order to improve efficiency, modified getItems() method in DeliveryPipelineView to only return the jobs that are displayed in the pipeline view.