### PR TITLE
JENKINS 35507 Fixed pagination performance issue when having large number of historical builds

### DIFF
--- a/src/main/java/se/diabol/jenkins/pipeline/domain/Component.java
+++ b/src/main/java/se/diabol/jenkins/pipeline/domain/Component.java
@@ -30,37 +30,35 @@ import se.diabol.jenkins.pipeline.PipelinePagination;
 
 import java.util.List;
 
-
 @ExportedBean(defaultVisibility = AbstractItem.VISIBILITY)
 public class Component extends AbstractItem {
-    private final List<Pipeline> pipelines;
+    private List<Pipeline> pipelines;
     private final String firstJob;
     private final String firstJobUrl;
     private final boolean firstJobParameterized;
     private final int noOfPipelines;
     private int componentNumber = 0;
     private boolean pagingEnabled = false;
+    private int totalNoOfPipelines = 0;
 
     public Component(String name, String firstJob, String firstJobUrl, boolean firstJobParameterized,
-            List<Pipeline> pipelines, int noOfPipelines, boolean pagingEnabled) {
+                     int noOfPipelines, boolean pagingEnabled, int componentNumber) {
         super(name);
-        this.pipelines = ImmutableList.copyOf(pipelines);
         this.firstJob = firstJob;
         this.firstJobUrl = firstJobUrl;
         this.firstJobParameterized = firstJobParameterized;
         this.noOfPipelines = noOfPipelines;
         this.pagingEnabled = pagingEnabled;
+        this.componentNumber = componentNumber;
     }
 
     @Exported
     public List<Pipeline> getPipelines() {
-        if (pagingEnabled && !isFullScreenView()) {
-            int startIndex = ((this.getCurrentPage() - 1) * noOfPipelines);
-            int retrieveSize = Math.min(pipelines.size() - ((this.getCurrentPage() - 1) * noOfPipelines),
-                    noOfPipelines);
-            return pipelines.subList(startIndex, startIndex + retrieveSize);
-        }
         return pipelines;
+    }
+
+    public void setPipelines(List<Pipeline> pipelines) {
+        this.pipelines = ImmutableList.copyOf(pipelines);
     }
 
     @Exported
@@ -91,23 +89,25 @@ public class Component extends AbstractItem {
         return getPagination().getTag();
     }
 
-    private PipelinePagination getPagination() {
+    public int getTotalNoOfPipelines() {
+        return totalNoOfPipelines;
+    }
+
+    public PipelinePagination getPagination() {
         if (pagingEnabled) {
-            return new PipelinePagination(this.getCurrentPage(), pipelines.size(), noOfPipelines, "?"
-                    + (this.isFullScreenView() ? "fullscreen=true&" : "fullscreen=false&")
+            return new PipelinePagination(this.getCurrentPage(), totalNoOfPipelines, noOfPipelines, "?"
+                    + (this.isFullScreenView() == true ? "fullscreen=true&" : "fullscreen=false&")
                     + "component=" + componentNumber + "&page=");
         }
         return null;
     }
 
-    private int getCurrentPage() {
-        StaplerRequest req = Stapler.getCurrentRequest();    
-        if (req == null) {
-            return 1;
-        }
-        int page = req.getParameter("page") == null ? 1 : Integer.parseInt(req.getParameter("page").toString());
+    public int getCurrentPage() {
+        StaplerRequest req = Stapler.getCurrentRequest();
+        int page = req == null ? 1 : req.getParameter("page") == null ? 1 :
+                Integer.parseInt(req.getParameter("page").toString());
         page = Math.max(page, 1);
-        int component = req.getParameter("component") == null ? 1 :
+        int component = req == null ? 1 : req.getParameter("component") == null ? 1 :
                 Integer.parseInt(req.getParameter("component").toString());
         if (component != componentNumber) {
             page = 1;
@@ -115,10 +115,10 @@ public class Component extends AbstractItem {
         return page;
     }
 
-    private boolean isFullScreenView() {
+    public boolean isFullScreenView() {
         StaplerRequest req = Stapler.getCurrentRequest();
-        return req != null && req.getParameter("fullscreen") != null
-                && Boolean.parseBoolean(req.getParameter("fullscreen"));
+        return req == null ? false : req.getParameter("fullscreen") == null ? false :
+                Boolean.parseBoolean(req.getParameter("fullscreen"));
     }
 
     @Exported
@@ -126,7 +126,7 @@ public class Component extends AbstractItem {
         return componentNumber;
     }
 
-    public void setComponentNumber(int componentNumber) {
-        this.componentNumber = componentNumber;
+    public void setTotalNoOfPipelines(int totalNoOfPipelines) {
+        this.totalNoOfPipelines = totalNoOfPipelines;
     }
 }

--- a/src/test/java/se/diabol/jenkins/pipeline/PipelinePaginationTest.java
+++ b/src/test/java/se/diabol/jenkins/pipeline/PipelinePaginationTest.java
@@ -61,10 +61,8 @@ public class PipelinePaginationTest {
     
     @Test
     public void testComponentNumber() {
-        Component componentB = new Component("B", "B", "job/A", false, new ArrayList<Pipeline>(), 3, pagingEnabledTrue);
-        componentB.setComponentNumber(2);
-        Component componentA = new Component("A", "A", "job/B", false, new ArrayList<Pipeline>(), 3, pagingEnabledTrue);
-        componentA.setComponentNumber(1);
+        Component componentB = new Component("B", "B", "job/A", false, 3, pagingEnabledTrue, 2);
+        Component componentA = new Component("A", "A", "job/B", false, 3, pagingEnabledTrue, 1);
         List<Component> list = new ArrayList<Component>();
         list.add(componentA);  
         list.add(componentB);
@@ -74,8 +72,8 @@ public class PipelinePaginationTest {
     
     @Test
     public void testComponent() {
-        Component componentA = new Component("A", "A", "job/B", false, new ArrayList<Pipeline>(), 3, pagingEnabledTrue);
-        componentA.setComponentNumber(1);
+        Component componentA = new Component("A", "A", "job/B", false, 3, pagingEnabledTrue, 1);
+        componentA.setPipelines(new ArrayList<Pipeline>());
         assertNotNull(componentA.getPagingData());
         assertNotNull(componentA.getPipelines());
     }

--- a/src/test/java/se/diabol/jenkins/pipeline/domain/ComponentTest.java
+++ b/src/test/java/se/diabol/jenkins/pipeline/domain/ComponentTest.java
@@ -1,0 +1,100 @@
+/*
+This file is part of Delivery Pipeline Plugin.
+
+Delivery Pipeline Plugin is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Delivery Pipeline Plugin is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Delivery Pipeline Plugin.
+If not, see <http://www.gnu.org/licenses/>.
+*/
+package se.diabol.jenkins.pipeline.domain;
+
+import hudson.model.FreeStyleProject;
+import hudson.tasks.BuildTrigger;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.WithoutJenkins;
+import org.mockito.runners.MockitoJUnitRunner;
+import se.diabol.jenkins.pipeline.DeliveryPipelineView;
+import se.diabol.jenkins.pipeline.PipelineProperty;
+import java.util.*;
+import static org.junit.Assert.*;
+
+
+@RunWith(MockitoJUnitRunner.class)
+public class ComponentTest {
+
+    @Rule
+    public JenkinsRule jenkins = new JenkinsRule();
+    private final static boolean pagingEnabledFalse = false;
+
+    @Test
+    @WithoutJenkins
+    public void testSettersAndGetters() {
+        Component component = new Component("Component", "Build", null, false, 10, pagingEnabledFalse, 1);
+        component.setTotalNoOfPipelines(10);
+        component.setPipelines(new ArrayList<Pipeline>());
+        assertEquals(1, component.getComponentNumber());
+        assertEquals("Component", component.getName());
+        assertEquals("Build", component.getFirstJob());
+        assertFalse(component.isFirstJobParameterized());
+        assertNull(component.getFirstJobUrl());
+        assertEquals(0, component.getPipelines().size());
+        assertNotNull(component.getPipelines());
+    }
+
+    @Test
+    public void testComponentPaging() throws Exception {
+        FreeStyleProject compile = jenkins.createFreeStyleProject("comp");
+        FreeStyleProject deploy = jenkins.createFreeStyleProject("deploy");
+        FreeStyleProject test = jenkins.createFreeStyleProject("test");
+
+        compile.addProperty(new PipelineProperty("Compile", "Build", ""));
+        compile.save();
+
+        deploy.addProperty(new PipelineProperty("Deploy", "Deploy", ""));
+        deploy.save();
+        test.addProperty(new PipelineProperty("Test", "Test", ""));
+        test.save();
+
+        compile.getPublishersList().add(new BuildTrigger("test", false));
+        test.getPublishersList().add(new BuildTrigger("deploy", false));
+
+        jenkins.getInstance().rebuildDependencyGraph();
+        DeliveryPipelineView view = new DeliveryPipelineView("Pipeline");
+        view.setPagingEnabled(true);
+
+        DeliveryPipelineView.ComponentSpec componentSpec = new DeliveryPipelineView.ComponentSpec("Pipeline","comp", null);
+        List<DeliveryPipelineView.ComponentSpec> componentSpecs = new ArrayList<DeliveryPipelineView.ComponentSpec>();
+        componentSpecs.add(componentSpec);
+        view.setComponentSpecs(componentSpecs);
+
+        jenkins.getInstance().addView(view);
+
+        jenkins.setQuietPeriod(0);
+        for(int loopIndex=0; loopIndex < 5; loopIndex++) {
+            jenkins.buildAndAssertSuccess(compile);
+            jenkins.waitUntilNoActivity();
+        }
+
+        assertNotNull(view);
+        assertEquals(1, view.getPipelines().size());
+        assertEquals("Pipeline", view.getViewName());
+        assertTrue(view.getPagingEnabled());
+        Component component = view.getPipelines().get(0);
+        assertEquals(1, component.getCurrentPage());
+        assertEquals(3, component.getPipelines().size());
+        assertEquals(5, component.getTotalNoOfPipelines());
+        assertNotNull(component.getPagingData());
+    }
+}

--- a/src/test/java/se/diabol/jenkins/pipeline/domain/status/SimpleStatusTest.java
+++ b/src/test/java/se/diabol/jenkins/pipeline/domain/status/SimpleStatusTest.java
@@ -33,6 +33,7 @@ import hudson.util.OneShotEvent;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Calendar;
+import java.util.Collections;
 import java.util.List;
 
 import org.junit.After;
@@ -45,15 +46,22 @@ import org.jvnet.hudson.test.WithoutJenkins;
 import org.jvnet.hudson.test.FailureBuilder;
 import org.jvnet.hudson.test.MockBuilder;
 import org.jvnet.hudson.test.UnstableBuilder;
+import org.kohsuke.stapler.RequestImpl;
+import org.kohsuke.stapler.Stapler;
+import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.WebApp;
 import org.mockito.Mockito;
 import org.mockito.runners.MockitoJUnitRunner;
 
+import se.diabol.jenkins.pipeline.domain.Component;
 import se.diabol.jenkins.pipeline.domain.Pipeline;
 import se.diabol.jenkins.pipeline.domain.status.promotion.AbstractPromotionStatusProvider;
 import se.diabol.jenkins.pipeline.domain.status.promotion.PromotionStatus;
 import au.com.centrumsystems.hudson.plugin.buildpipeline.BuildPipelineView;
 import au.com.centrumsystems.hudson.plugin.buildpipeline.DownstreamProjectGridBuilder;
 import au.com.centrumsystems.hudson.plugin.buildpipeline.trigger.BuildPipelineTrigger;
+
+import javax.servlet.http.HttpServletRequest;
 
 @RunWith(MockitoJUnitRunner.class)
 public class SimpleStatusTest {
@@ -345,6 +353,7 @@ public class SimpleStatusTest {
 
     @Test
     public void testCheckThatAllOnlyQueuedBuildIsResolvedAsQueued() throws Exception {
+        StaplerRequest request = Mockito.mock(StaplerRequest.class);
         FreeStyleProject project1 = jenkins.createFreeStyleProject("project1");
         jenkins.createFreeStyleProject("project2");
         project1.getPublishersList().add(new BuildPipelineTrigger("project2", null));
@@ -355,7 +364,8 @@ public class SimpleStatusTest {
         jenkins.buildAndAssertSuccess(project1);
         jenkins.waitUntilNoActivity();
 
-        List<Pipeline> pipelines = pipeline.createPipelineLatest(2, jenkins.getInstance(), pagingEnabledFalse);
+        Component component = new Component("Component","project1", null, false, 3, pagingEnabledFalse, 1);
+        List<Pipeline> pipelines = pipeline.createPipelineLatest(2, jenkins.getInstance(), pagingEnabledFalse, component);
         assertEquals(2, pipelines.size());
         assertEquals(StatusType.IDLE, pipelines.get(0).getStages().get(1).getTasks().get(0).getStatus().getType());
         assertEquals(StatusType.IDLE, pipelines.get(1).getStages().get(1).getTasks().get(0).getStatus().getType());
@@ -363,13 +373,13 @@ public class SimpleStatusTest {
         BuildPipelineView view = new BuildPipelineView("", "", new DownstreamProjectGridBuilder("project1"), "0", false, "");
         project1.setQuietPeriod(3);
         view.triggerManualBuild(1, "project2", "project1");
-        pipelines = pipeline.createPipelineLatest(2, jenkins.getInstance(), pagingEnabledFalse);
+        pipelines = pipeline.createPipelineLatest(2, jenkins.getInstance(), pagingEnabledFalse, component);
         assertEquals(2, pipelines.size());
         assertEquals(StatusType.IDLE, pipelines.get(0).getStages().get(1).getTasks().get(0).getStatus().getType());
         assertEquals(StatusType.QUEUED, pipelines.get(1).getStages().get(1).getTasks().get(0).getStatus().getType());
 
         jenkins.waitUntilNoActivity();
-        pipelines = pipeline.createPipelineLatest(2, jenkins.getInstance(), pagingEnabledFalse);
+        pipelines = pipeline.createPipelineLatest(2, jenkins.getInstance(), pagingEnabledFalse, component);
         assertEquals(2, pipelines.size());
         assertEquals(StatusType.IDLE, pipelines.get(0).getStages().get(1).getTasks().get(0).getStatus().getType());
         assertEquals(StatusType.SUCCESS, pipelines.get(1).getStages().get(1).getTasks().get(0).getStatus().getType());

--- a/src/test/java/se/diabol/jenkins/pipeline/sort/LatestActivityComparatorTest.java
+++ b/src/test/java/se/diabol/jenkins/pipeline/sort/LatestActivityComparatorTest.java
@@ -63,8 +63,10 @@ public class LatestActivityComparatorTest {
         pipelinesB.add(pipelineB);
 
 
-        Component componentB = new Component("B", "B", "job/A", false, pipelinesB, 3, pagingEnabledFalse);
-        Component componentA = new Component("A", "A", "job/B", false, pipelinesA, 3, pagingEnabledFalse);
+        Component componentB = new Component("B", "B", "job/A", false, 3, pagingEnabledFalse,1);
+        Component componentA = new Component("A", "A", "job/B", false, 3, pagingEnabledFalse, 1);
+        componentB.setPipelines(pipelinesB);
+        componentA.setPipelines(pipelinesA);
         List<Component> list = new ArrayList<Component>();
         list.add(componentB);
         list.add(componentA);

--- a/src/test/java/se/diabol/jenkins/pipeline/sort/NameComparatorTest.java
+++ b/src/test/java/se/diabol/jenkins/pipeline/sort/NameComparatorTest.java
@@ -33,8 +33,8 @@ public class NameComparatorTest {
 
     @Test
     public void testCompare() {
-        Component componentB = new Component("B", "B", "job/A", false, new ArrayList<Pipeline>(), 3, pagingEnabledFalse);
-        Component componentA = new Component("A", "A", "job/B", false, new ArrayList<Pipeline>(), 3, pagingEnabledFalse);
+        Component componentB = new Component("B", "B", "job/A", false, 3, pagingEnabledFalse, 1);
+        Component componentA = new Component("A", "A", "job/B", false, 3, pagingEnabledFalse, 2);
         List<Component> list = new ArrayList<Component>();
         list.add(componentB);
         list.add(componentA);


### PR DESCRIPTION
According to the current design after getting pipelines only component is getting created. As pagination can be implemented at component level previously I didn't change the flow of current design, but because of this it has shown impact on the performance where when having large number of historical builds.
So to fix this performance issue I have to change the current design of elements creation flow. Before creating the pipelines first created component and passed that component to the method createPipelineLatest to get the pipelines exactly required for selected page.