### PR TITLE
[JENKINS-35683] Check all upstream projects for manual triggers

### DIFF
--- a/src/main/java/se/diabol/jenkins/pipeline/trigger/BPPManualTriggerResolver.java
+++ b/src/main/java/se/diabol/jenkins/pipeline/trigger/BPPManualTriggerResolver.java
@@ -53,8 +53,7 @@ public class BPPManualTriggerResolver extends ManualTriggerResolver {
 
     public boolean isManualTrigger(AbstractProject<?, ?> project) {
         List<AbstractProject> upstreamProjects = project.getUpstreamProjects();
-        if (upstreamProjects.size() > 0) {
-            AbstractProject<?,?> upstreamProject = upstreamProjects.get(0);
+        for (AbstractProject upstreamProject : upstreamProjects) {
             DescribableList<Publisher, Descriptor<Publisher>> upstreamPublishersLists =
                     upstreamProject.getPublishersList();
             for (Publisher upstreamPub : upstreamPublishersLists) {

--- a/src/test/java/se/diabol/jenkins/pipeline/trigger/BPPManualTriggerResolverTest.java
+++ b/src/test/java/se/diabol/jenkins/pipeline/trigger/BPPManualTriggerResolverTest.java
@@ -19,6 +19,7 @@ package se.diabol.jenkins.pipeline.trigger;
 
 import au.com.centrumsystems.hudson.plugin.buildpipeline.trigger.BuildPipelineTrigger;
 import hudson.model.FreeStyleProject;
+import hudson.tasks.BuildTrigger;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
@@ -26,6 +27,7 @@ import org.jvnet.hudson.test.MockFolder;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 public class BPPManualTriggerResolverTest {
 
@@ -68,4 +70,17 @@ public class BPPManualTriggerResolverTest {
         assertNotNull(new BPPManualTriggerResolver().getManualTrigger(b, a));
     }
 
+    @Test
+    public void testIsManualTriggerMultipleUpstreams() throws Exception {
+        FreeStyleProject a = jenkins.createFreeStyleProject("a");
+        FreeStyleProject b = jenkins.createFreeStyleProject("b");
+        FreeStyleProject c = jenkins.createFreeStyleProject("c");
+
+        a.getPublishersList().add(new BuildTrigger("c", true));
+        b.getPublishersList().add(new BuildPipelineTrigger("c", null));
+
+        jenkins.getInstance().rebuildDependencyGraph();
+
+        assertTrue(new BPPManualTriggerResolver().isManualTrigger(c));
+    }
 }


### PR DESCRIPTION
My pipelines were missing some manual triggers. This was caused by some jobs having multiple upstream projects. Only the first upstream project was being checked for a manual trigger.

This change checks all upstream projects for a manual trigger in isManualTrigger