### PR TITLE
[JENKINS-35951] Performance improvements for loading changes

### DIFF
--- a/src/main/java/se/diabol/jenkins/pipeline/DeliveryPipelineView.java
+++ b/src/main/java/se/diabol/jenkins/pipeline/DeliveryPipelineView.java
@@ -514,9 +514,10 @@ public class DeliveryPipelineView extends View {
             pipelines.add(pipeline.createPipelineAggregated(getOwnerItemGroup(), showAggregatedChanges));
         }
         if (isFullScreenView()) {
-            pipelines.addAll(pipeline.createPipelineLatest(noOfPipelines, getOwnerItemGroup(), false));
+            pipelines.addAll(pipeline.createPipelineLatest(noOfPipelines, getOwnerItemGroup(), false, showChanges));
         } else {
-            pipelines.addAll(pipeline.createPipelineLatest(noOfPipelines, getOwnerItemGroup(), pagingEnabled));
+            pipelines.addAll(pipeline
+                    .createPipelineLatest(noOfPipelines, getOwnerItemGroup(), pagingEnabled, showChanges));
         }
         return new Component(name, firstJob.getName(), firstJob.getUrl(), firstJob.isParameterized(), pipelines,
                 noOfPipelines, pagingEnabled);

--- a/src/main/java/se/diabol/jenkins/pipeline/domain/Pipeline.java
+++ b/src/main/java/se/diabol/jenkins/pipeline/domain/Pipeline.java
@@ -235,7 +235,8 @@ public class Pipeline extends AbstractItem {
      *
      * @param noOfPipelines number of pipeline instances
      */
-    public List<Pipeline> createPipelineLatest(int noOfPipelines, ItemGroup context, boolean pagingEnabled) {
+    public List<Pipeline> createPipelineLatest(int noOfPipelines, ItemGroup context,
+                                               boolean pagingEnabled, boolean showChanges) {
         List<Pipeline> result = new ArrayList<Pipeline>();
         int no = noOfPipelines;
         if (firstProject.isInQueue()) {
@@ -258,7 +259,9 @@ public class Pipeline extends AbstractItem {
         Iterator it = firstProject.getBuilds().iterator();
         for (int i = 0; i < pipelineCount && it.hasNext(); i++) {
             AbstractBuild firstBuild = (AbstractBuild) it.next();
-            List<Change> pipelineChanges = Change.getChanges(firstBuild);
+            List<Change> pipelineChanges = showChanges ? Change.getChanges(firstBuild) : null;
+            Set<UserInfo> contributors = showChanges ? UserInfo.getContributors(pipelineChanges) : null;
+
             String pipeLineTimestamp = PipelineUtils.formatTimestamp(firstBuild.getTimeInMillis());
             List<Stage> pipelineStages = new ArrayList<Stage>();
             for (Stage stage : getStages()) {
@@ -266,7 +269,7 @@ public class Pipeline extends AbstractItem {
             }
             Pipeline pipelineLatest = new Pipeline(getName(), firstProject, lastProject, firstBuild.getDisplayName(),
                     pipeLineTimestamp, TriggerCause.getTriggeredBy(firstProject, firstBuild),
-                    UserInfo.getContributors(firstBuild), pipelineStages, false);
+                    contributors, pipelineStages, false);
             pipelineLatest.setChanges(pipelineChanges);
             pipelineLatest.calculateTotalBuildTime();
             result.add(pipelineLatest);

--- a/src/main/java/se/diabol/jenkins/pipeline/domain/UserInfo.java
+++ b/src/main/java/se/diabol/jenkins/pipeline/domain/UserInfo.java
@@ -17,12 +17,11 @@ If not, see <http://www.gnu.org/licenses/>.
 */
 package se.diabol.jenkins.pipeline.domain;
 
-import hudson.model.AbstractBuild;
 import hudson.model.User;
-import hudson.scm.ChangeLogSet;
 import org.kohsuke.stapler.export.Exported;
 
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 public class UserInfo extends AbstractItem {
@@ -43,10 +42,10 @@ public class UserInfo extends AbstractItem {
         return new UserInfo(user.getDisplayName(), user.getUrl());
     }
 
-    public static Set<UserInfo> getContributors(AbstractBuild<?, ?> build) {
+    public static Set<UserInfo> getContributors(List<Change> changes) {
         Set<UserInfo> contributors = new HashSet<UserInfo>();
-        for (ChangeLogSet.Entry entry : build.getChangeSet()) {
-            contributors.add(UserInfo.getUser(entry.getAuthor()));
+        for (Change change : changes) {
+            contributors.add(change.getAuthor());
         }
         return contributors;
     }

--- a/src/test/java/se/diabol/jenkins/pipeline/DeliveryPipelineViewTest.java
+++ b/src/test/java/se/diabol/jenkins/pipeline/DeliveryPipelineViewTest.java
@@ -406,13 +406,20 @@ public class DeliveryPipelineViewTest {
         jenkins.setQuietPeriod(0);
         jenkins.buildAndAssertSuccess(build);
 
+        view.setShowChanges(false);
+        components = view.getPipelines();
+        Pipeline pipeline = components.get(0).getPipelines().get(0);
+        assertNull(pipeline.getContributors());
+        assertNull(pipeline.getChanges());
+
+        view.setShowChanges(true);
         components = view.getPipelines();
         assertNull(view.getError());
         assertEquals(1, components.size());
         component = components.get(0);
         assertEquals(1, component.getPipelines().size());
         assertEquals("Comp", component.getName());
-        Pipeline pipeline = component.getPipelines().get(0);
+        pipeline = component.getPipelines().get(0);
         assertEquals("#1", pipeline.getVersion());
         assertNotNull(pipeline.getTimestamp());
         assertFalse(pipeline.isAggregated());

--- a/src/test/java/se/diabol/jenkins/pipeline/domain/PipelineTest.java
+++ b/src/test/java/se/diabol/jenkins/pipeline/domain/PipelineTest.java
@@ -61,6 +61,7 @@ public class PipelineTest {
     @Rule
     public JenkinsRule jenkins = new JenkinsRule();
     private final static boolean pagingEnabledFalse = false;
+    private final static boolean showChanges = true;
 
     @Test
     public void testExtractPipelineEmptyPropertyAndNullProperty() throws Exception {
@@ -418,7 +419,7 @@ public class PipelineTest {
 
         assertEquals(build.getLastBuild(), BuildUtil.getFirstUpstreamBuild(build.getLastBuild(), build));
         Pipeline pipeline = Pipeline.extractPipeline("Pipeline", build);
-        List<Pipeline> pipelines = pipeline.createPipelineLatest(1, Jenkins.getInstance(), pagingEnabledFalse);
+        List<Pipeline> pipelines = pipeline.createPipelineLatest(1, Jenkins.getInstance(), pagingEnabledFalse, showChanges);
         assertEquals(1, pipelines.size());
         assertEquals(1, pipelines.get(0).getTriggeredBy().size());
         assertEquals(TriggerCause.TYPE_UPSTREAM, pipelines.get(0).getTriggeredBy().get(0).getType());
@@ -701,14 +702,14 @@ public class PipelineTest {
         FreeStyleProject a = jenkins.createFreeStyleProject("A");
         Pipeline prototype = Pipeline.extractPipeline("Pipe", a);
         a.scheduleBuild(2, new Cause.UserIdCause());
-        List<Pipeline> pipelines = prototype.createPipelineLatest(5, Jenkins.getInstance(), pagingEnabledFalse);
+        List<Pipeline> pipelines = prototype.createPipelineLatest(5, Jenkins.getInstance(), pagingEnabledFalse, showChanges);
         assertEquals(1, pipelines.size());
 
 
     }
 
     private Pipeline createPipelineLatest(Pipeline pipeline, ItemGroup itemGroup) {
-        List<Pipeline> pipelines = pipeline.createPipelineLatest(1, itemGroup, pagingEnabledFalse);
+        List<Pipeline> pipelines = pipeline.createPipelineLatest(1, itemGroup, pagingEnabledFalse, showChanges);
         assertFalse(pipelines.isEmpty());
         return pipelines.get(0);
     }

--- a/src/test/java/se/diabol/jenkins/pipeline/domain/UserInfoTest.java
+++ b/src/test/java/se/diabol/jenkins/pipeline/domain/UserInfoTest.java
@@ -42,7 +42,7 @@ public class UserInfoTest {
         jenkins.setQuietPeriod(0);
         project.scheduleBuild(new Cause.UserIdCause());
         jenkins.waitUntilNoActivity();
-        Set<UserInfo> contributors = UserInfo.getContributors(project.getLastBuild());
+        Set<UserInfo> contributors = UserInfo.getContributors(Change.getChanges(project.getLastBuild()));
         assertEquals(0, contributors.size());
     }
 
@@ -56,7 +56,7 @@ public class UserInfoTest {
         jenkins.setQuietPeriod(0);
         project.scheduleBuild(new Cause.UserIdCause());
         jenkins.waitUntilNoActivity();
-        Set<UserInfo> contributors = UserInfo.getContributors(project.getLastBuild());
+        Set<UserInfo> contributors = UserInfo.getContributors(Change.getChanges(project.getLastBuild()));
         assertEquals(2, contributors.size());
         assertTrue(contributors.contains(new UserInfo("test-user1", null)));
         assertTrue(contributors.contains(new UserInfo("test-user2", null)));
@@ -85,7 +85,7 @@ public class UserInfoTest {
 
         assertEquals(3, build.getCulprits().size());
 
-        Set<UserInfo> contributors = UserInfo.getContributors(project.getLastBuild());
+        Set<UserInfo> contributors = UserInfo.getContributors(Change.getChanges(project.getLastBuild()));
         assertEquals(1, contributors.size());
         UserInfo user = contributors.iterator().next();
         assertEquals("test-user", user.getName());

--- a/src/test/java/se/diabol/jenkins/pipeline/domain/status/SimpleStatusTest.java
+++ b/src/test/java/se/diabol/jenkins/pipeline/domain/status/SimpleStatusTest.java
@@ -62,6 +62,7 @@ public class SimpleStatusTest {
     public JenkinsRule jenkins = new JenkinsRule();
 
     private final static boolean pagingEnabledFalse = false;
+    private final static boolean showChanges = true;
 
     private SimpleStatus.PromotionStatusProviderWrapper defaultNotMockedPromotionStatusProviderWrapper = new SimpleStatus.PromotionStatusProviderWrapper();
 
@@ -355,7 +356,7 @@ public class SimpleStatusTest {
         jenkins.buildAndAssertSuccess(project1);
         jenkins.waitUntilNoActivity();
 
-        List<Pipeline> pipelines = pipeline.createPipelineLatest(2, jenkins.getInstance(), pagingEnabledFalse);
+        List<Pipeline> pipelines = pipeline.createPipelineLatest(2, jenkins.getInstance(), pagingEnabledFalse, showChanges);
         assertEquals(2, pipelines.size());
         assertEquals(StatusType.IDLE, pipelines.get(0).getStages().get(1).getTasks().get(0).getStatus().getType());
         assertEquals(StatusType.IDLE, pipelines.get(1).getStages().get(1).getTasks().get(0).getStatus().getType());
@@ -363,13 +364,13 @@ public class SimpleStatusTest {
         BuildPipelineView view = new BuildPipelineView("", "", new DownstreamProjectGridBuilder("project1"), "0", false, "");
         project1.setQuietPeriod(3);
         view.triggerManualBuild(1, "project2", "project1");
-        pipelines = pipeline.createPipelineLatest(2, jenkins.getInstance(), pagingEnabledFalse);
+        pipelines = pipeline.createPipelineLatest(2, jenkins.getInstance(), pagingEnabledFalse, showChanges);
         assertEquals(2, pipelines.size());
         assertEquals(StatusType.IDLE, pipelines.get(0).getStages().get(1).getTasks().get(0).getStatus().getType());
         assertEquals(StatusType.QUEUED, pipelines.get(1).getStages().get(1).getTasks().get(0).getStatus().getType());
 
         jenkins.waitUntilNoActivity();
-        pipelines = pipeline.createPipelineLatest(2, jenkins.getInstance(), pagingEnabledFalse);
+        pipelines = pipeline.createPipelineLatest(2, jenkins.getInstance(), pagingEnabledFalse, showChanges);
         assertEquals(2, pipelines.size());
         assertEquals(StatusType.IDLE, pipelines.get(0).getStages().get(1).getTasks().get(0).getStatus().getType());
         assertEquals(StatusType.SUCCESS, pipelines.get(1).getStages().get(1).getTasks().get(0).getStatus().getType());


### PR DESCRIPTION
Improvements:
- Prevent additional access to the change set by extracting contributors from already extracted changes
- Return `null` for `changes` and `contributors` if `showChanges` is enabled, preventing additional server-side operations
