### PR TITLE
Manual ordering of the Components and Regular Expression in Configure screen using Drag n Drop of repeatable property.

### DIFF
--- a/src/main/resources/se/diabol/jenkins/pipeline/DeliveryPipelineView/ComponentSpec/config.jelly
+++ b/src/main/resources/se/diabol/jenkins/pipeline/DeliveryPipelineView/ComponentSpec/config.jelly
@@ -11,8 +11,10 @@
         <f:entry title="Final Job (optional)" field="lastJob">
             <f:select/>
         </f:entry>
-        <div align="right">
-            <f:repeatableDeleteButton/>
-        </div>
+        <f:entry>
+            <div align="right">
+                <f:repeatableDeleteButton/>
+            </div>
+        </f:entry>
     </div>
 </j:jelly>

--- a/src/main/resources/se/diabol/jenkins/pipeline/DeliveryPipelineView/RegExpSpec/config.jelly
+++ b/src/main/resources/se/diabol/jenkins/pipeline/DeliveryPipelineView/RegExpSpec/config.jelly
@@ -5,9 +5,10 @@
         <f:entry title="Regular Expression" field="regexp">
             <f:textbox/>
         </f:entry>
-        <div align="right">
-            <f:repeatableDeleteButton/>
-        </div>
-
+        <f:entry>
+            <div align="right">
+                <f:repeatableDeleteButton/>
+            </div>
+        </f:entry>
     </div>
 </j:jelly>

--- a/src/main/resources/se/diabol/jenkins/pipeline/DeliveryPipelineView/configure-entries.jelly
+++ b/src/main/resources/se/diabol/jenkins/pipeline/DeliveryPipelineView/configure-entries.jelly
@@ -100,10 +100,10 @@
 
     <f:section title="Pipelines">
         <f:entry title="Components">
-            <f:repeatableProperty minimum="0" field="componentSpecs"/>
+            <f:repeatableProperty minimum="0" field="componentSpecs" header="Component"/>
         </f:entry>
         <f:entry title="Regular Expression">
-            <f:repeatableProperty minimum="0" field="regexpFirstJobs"/>
+            <f:repeatableProperty minimum="0" field="regexpFirstJobs" header="RegEx"/>
         </f:entry>
     </f:section>
 


### PR DESCRIPTION
Along with this "Delete" button position also moved to bottom instead of top corner and it is also not properly aligned with form.

![dpp](https://cloud.githubusercontent.com/assets/8586903/17149725/2f6b40b4-538a-11e6-9307-7cdb7ba23541.PNG)

This is my observation today and thought of submit the PR.

@tommysdk 
Go through this PR very small amount of fix, It may help some users who want to re-order the components or regular expression blocks.

At present there is no JIRA number for this. Let me know if this is ok I will create task in JIRA.