### PR TITLE
JENKINS-22283 Show upstream jobs

### DIFF
--- a/src/main/java/se/diabol/jenkins/pipeline/DeliveryPipelineView.java
+++ b/src/main/java/se/diabol/jenkins/pipeline/DeliveryPipelineView.java
@@ -482,7 +482,8 @@ public class DeliveryPipelineView extends View {
                     AbstractProject lastJob = ProjectUtil.getProject(componentSpec.getLastJob(), getOwnerItemGroup());
                     if (firstJob != null) {
                         components.add(getComponent(componentSpec.getName(), firstJob,
-                                lastJob, showAggregatedPipeline, (componentSpecs.indexOf(componentSpec) + 1)));
+                                lastJob, showAggregatedPipeline, (componentSpecs.indexOf(componentSpec) + 1),
+                                componentSpec.isShowUpstream()));
                     } else {
                         throw new PipelineException("Could not find project: " + componentSpec.getFirstJob());
                     }
@@ -494,7 +495,7 @@ public class DeliveryPipelineView extends View {
                     int index = 1;
                     for (Map.Entry<String, AbstractProject> entry : matches.entrySet()) {
                         components.add(getComponent(entry.getKey(), entry.getValue(), null,
-                                showAggregatedPipeline, index));
+                                showAggregatedPipeline, index, regexp.isShowUpstream()));
                         index++;
                     }
                 }
@@ -519,7 +520,8 @@ public class DeliveryPipelineView extends View {
     }
 
     private Component getComponent(String name, AbstractProject firstJob, AbstractProject lastJob,
-                                   boolean showAggregatedPipeline, int componentNumber) throws PipelineException {
+                                   boolean showAggregatedPipeline, int componentNumber, boolean showUpstream)
+            throws PipelineException {
         Pipeline pipeline = Pipeline.extractPipeline(name, firstJob, lastJob);
         Component component = new Component(name, firstJob.getName(), firstJob.getUrl(), firstJob.isParameterized(),
                 noOfPipelines, pagingEnabled, componentNumber);
@@ -529,10 +531,11 @@ public class DeliveryPipelineView extends View {
         }
         if (isFullScreenView()) {
             pipelines.addAll(pipeline
-                    .createPipelineLatest(noOfPipelines, getOwnerItemGroup(), false, showChanges, component));
+                    .createPipelineLatest(noOfPipelines, getOwnerItemGroup(), false, showChanges,
+                            showUpstream, component));
         } else {
             pipelines.addAll(pipeline.createPipelineLatest(noOfPipelines, getOwnerItemGroup(),
-                    pagingEnabled, showChanges, component));
+                    pagingEnabled, showChanges, showUpstream, component));
         }
         component.setPipelines(pipelines);
         return component;
@@ -648,15 +651,26 @@ public class DeliveryPipelineView extends View {
     public static class RegExpSpec extends AbstractDescribableImpl<RegExpSpec> {
 
         private String regexp;
+        private boolean showUpstream;
 
         @DataBoundConstructor
-        public RegExpSpec(String regexp) {
+        public RegExpSpec(String regexp, boolean showUpstream) {
             this.regexp = regexp;
+            this.showUpstream = showUpstream;
         }
 
         public String getRegexp() {
             return regexp;
         }
+
+        public boolean isShowUpstream() {
+            return showUpstream;
+        }
+
+        public void setShowUpstream(boolean showUpstream) {
+            this.showUpstream = showUpstream;
+        }
+
 
         @Extension
         public static class DescriptorImpl extends Descriptor<RegExpSpec> {
@@ -690,12 +704,14 @@ public class DeliveryPipelineView extends View {
         private String name;
         private String firstJob;
         private String lastJob;
+        private boolean showUpstream;
 
         @DataBoundConstructor
-        public ComponentSpec(String name, String firstJob, String lastJob) {
+        public ComponentSpec(String name, String firstJob, String lastJob, boolean showUpstream) {
             this.name = name;
             this.firstJob = firstJob;
             this.lastJob = lastJob;
+            this.showUpstream = showUpstream;
         }
 
         public String getName() {
@@ -716,6 +732,14 @@ public class DeliveryPipelineView extends View {
 
         public void setLastJob(String lastJob) {
             this.lastJob = lastJob;
+        }
+
+        public boolean isShowUpstream() {
+            return showUpstream;
+        }
+
+        public void setShowUpstream(boolean showUpstream) {
+            this.showUpstream = showUpstream;
         }
 
         @Extension

--- a/src/main/java/se/diabol/jenkins/pipeline/portlet/DeliveryPipelineViewPortlet.java
+++ b/src/main/java/se/diabol/jenkins/pipeline/portlet/DeliveryPipelineViewPortlet.java
@@ -87,7 +87,7 @@ public class DeliveryPipelineViewPortlet extends DashboardPortlet {
         List<DeliveryPipelineView.ComponentSpec> componentSpecs = new ArrayList<DeliveryPipelineView.ComponentSpec>();
         if (initialJob != null && !"".equals(initialJob.trim())) {
             DeliveryPipelineView.ComponentSpec componentSpec = new DeliveryPipelineView.ComponentSpec("Aggregated view",
-                    initialJob, finalJob);
+                    initialJob, finalJob, false);
             componentSpecs.add(componentSpec);
         }
         view.setComponentSpecs(componentSpecs);

--- a/src/main/java/se/diabol/jenkins/pipeline/util/ProjectUtil.java
+++ b/src/main/java/se/diabol/jenkins/pipeline/util/ProjectUtil.java
@@ -183,4 +183,28 @@ public final class ProjectUtil {
     }
 
 
+    public static List<AbstractProject> getStartUpstreams(AbstractProject project) {
+        List<AbstractProject> upstreams = project.getUpstreamProjects();
+        if (upstreams.isEmpty()) {
+            return new ArrayList<AbstractProject>(Collections.singleton(project));
+        } else {
+            return getStartUpstreams(project, new ArrayList<AbstractProject>());
+        }
+    }
+
+    private static List<AbstractProject> getStartUpstreams(AbstractProject project, List<AbstractProject> edges) {
+        List<AbstractProject> upstreams = project.getUpstreamProjects();
+        if (upstreams.isEmpty()) {
+            edges.add(project);
+            return edges;
+        } else {
+            List<AbstractProject> result = new ArrayList<AbstractProject>(edges);
+            for (AbstractProject upstream : upstreams) {
+                result = (getStartUpstreams(upstream, edges));
+            }
+            return result;
+        }
+    }
+
+
 }

--- a/src/main/resources/se/diabol/jenkins/pipeline/DeliveryPipelineView/ComponentSpec/config.jelly
+++ b/src/main/resources/se/diabol/jenkins/pipeline/DeliveryPipelineView/ComponentSpec/config.jelly
@@ -11,6 +11,9 @@
         <f:entry title="Final Job (optional)" field="lastJob">
             <f:select/>
         </f:entry>
+        <f:entry title="Show upstream (experimental feature)" field="showUpstream">
+            <f:checkbox/>
+        </f:entry>
         <f:entry>
             <div align="right">
                 <f:repeatableDeleteButton/>

--- a/src/main/resources/se/diabol/jenkins/pipeline/DeliveryPipelineView/RegExpSpec/config.jelly
+++ b/src/main/resources/se/diabol/jenkins/pipeline/DeliveryPipelineView/RegExpSpec/config.jelly
@@ -5,6 +5,9 @@
         <f:entry title="Regular Expression" field="regexp">
             <f:textbox/>
         </f:entry>
+        <f:entry title="Show upstream (experimental feature)" field="showUpstream">
+            <f:checkbox/>
+        </f:entry>
         <f:entry>
             <div align="right">
                 <f:repeatableDeleteButton/>

--- a/src/test/java/se/diabol/jenkins/pipeline/DeliveryPipelineViewTest.java
+++ b/src/test/java/se/diabol/jenkins/pipeline/DeliveryPipelineViewTest.java
@@ -92,8 +92,8 @@ public class DeliveryPipelineViewTest {
         FreeStyleProject p1 = jenkins.createFreeStyleProject("build1");
 
         List<DeliveryPipelineView.ComponentSpec> componentSpecs = new ArrayList<DeliveryPipelineView.ComponentSpec>();
-        componentSpecs.add(new DeliveryPipelineView.ComponentSpec("comp1", "build1", NONE));
-        componentSpecs.add(new DeliveryPipelineView.ComponentSpec("comp2", "build2", NONE));
+        componentSpecs.add(new DeliveryPipelineView.ComponentSpec("comp1", "build1", NONE, false));
+        componentSpecs.add(new DeliveryPipelineView.ComponentSpec("comp2", "build2", NONE, false));
 
         DeliveryPipelineView view = new DeliveryPipelineView("Test");
         view.setComponentSpecs(componentSpecs);
@@ -110,7 +110,7 @@ public class DeliveryPipelineViewTest {
         FreeStyleProject p2 = jenkins.createFreeStyleProject("build2");
 
         List<DeliveryPipelineView.ComponentSpec> componentSpecs = new ArrayList<DeliveryPipelineView.ComponentSpec>();
-        componentSpecs.add(new DeliveryPipelineView.ComponentSpec("comp1", "build1", "build2"));
+        componentSpecs.add(new DeliveryPipelineView.ComponentSpec("comp1", "build1", "build2", false));
 
         DeliveryPipelineView view = new DeliveryPipelineView("Test");
         view.setComponentSpecs(componentSpecs);
@@ -141,8 +141,8 @@ public class DeliveryPipelineViewTest {
         FreeStyleProject p1 = jenkins.createFreeStyleProject("build1");
 
         List<DeliveryPipelineView.ComponentSpec> componentSpecs = new ArrayList<DeliveryPipelineView.ComponentSpec>();
-        componentSpecs.add(new DeliveryPipelineView.ComponentSpec("comp1", "build1", NONE));
-        componentSpecs.add(new DeliveryPipelineView.ComponentSpec("comp2", "build2", NONE));
+        componentSpecs.add(new DeliveryPipelineView.ComponentSpec("comp1", "build1", NONE, false));
+        componentSpecs.add(new DeliveryPipelineView.ComponentSpec("comp2", "build2", NONE, false));
 
         DeliveryPipelineView view = new DeliveryPipelineView("Test");
         view.setComponentSpecs(componentSpecs);
@@ -311,7 +311,7 @@ public class DeliveryPipelineViewTest {
 
 
         List<DeliveryPipelineView.ComponentSpec> specs = new ArrayList<DeliveryPipelineView.ComponentSpec>();
-        specs.add(new DeliveryPipelineView.ComponentSpec("Comp", "build", NONE));
+        specs.add(new DeliveryPipelineView.ComponentSpec("Comp", "build", NONE, false));
         DeliveryPipelineView view = new DeliveryPipelineView("name");
         view.setComponentSpecs(specs);
         jenkins.getInstance().addView(view);
@@ -328,7 +328,7 @@ public class DeliveryPipelineViewTest {
     @Test
     public void testGetItemsGetPipelinesWhenNoProjectFound() throws Exception {
         List<DeliveryPipelineView.ComponentSpec> specs = new ArrayList<DeliveryPipelineView.ComponentSpec>();
-        specs.add(new DeliveryPipelineView.ComponentSpec("Comp", "build", NONE));
+        specs.add(new DeliveryPipelineView.ComponentSpec("Comp", "build", NONE, false));
         DeliveryPipelineView view = new DeliveryPipelineView("name");
         view.setComponentSpecs(specs);
         jenkins.getInstance().addView(view);
@@ -358,7 +358,7 @@ public class DeliveryPipelineViewTest {
 
 
         List<DeliveryPipelineView.ComponentSpec> specs = new ArrayList<DeliveryPipelineView.ComponentSpec>();
-        specs.add(new DeliveryPipelineView.ComponentSpec("Comp", "build", NONE));
+        specs.add(new DeliveryPipelineView.ComponentSpec("Comp", "build", NONE, false));
         DeliveryPipelineView view = new DeliveryPipelineView("name");
         view.setComponentSpecs(specs);
         folder.addView(view);
@@ -386,7 +386,7 @@ public class DeliveryPipelineViewTest {
         jenkins.waitUntilNoActivity();
 
         List<DeliveryPipelineView.ComponentSpec> specs = new ArrayList<DeliveryPipelineView.ComponentSpec>();
-        specs.add(new DeliveryPipelineView.ComponentSpec("Comp", "build", "test"));
+        specs.add(new DeliveryPipelineView.ComponentSpec("Comp", "build", "test", false));
         DeliveryPipelineView view = new DeliveryPipelineView("Pipeline");
         view.setComponentSpecs(specs);
         view.setSorting(NameComparator.class.getName());
@@ -399,8 +399,8 @@ public class DeliveryPipelineViewTest {
     public void testGetPipelinesUsesMaxNumberOfJobs() throws Exception {
         jenkins.createFreeStyleProject("build");
         List<DeliveryPipelineView.ComponentSpec> specs = new ArrayList<DeliveryPipelineView.ComponentSpec>();
-        specs.add(new DeliveryPipelineView.ComponentSpec("Comp", "build", NONE));
-        specs.add(new DeliveryPipelineView.ComponentSpec("Comp1", "build", NONE));
+        specs.add(new DeliveryPipelineView.ComponentSpec("Comp", "build", NONE, false));
+        specs.add(new DeliveryPipelineView.ComponentSpec("Comp1", "build", NONE, false));
         DeliveryPipelineView view = new DeliveryPipelineView("Pipeline");
         view.setComponentSpecs(specs);
         view.setMaxNumberOfVisiblePipelines(1);
@@ -415,7 +415,7 @@ public class DeliveryPipelineViewTest {
         jenkins.createFreeStyleProject("build");
         List<DeliveryPipelineView.ComponentSpec> specs = new ArrayList<DeliveryPipelineView.ComponentSpec>();
         for(int i = 0;i<100;i++) {
-            specs.add(new DeliveryPipelineView.ComponentSpec("Comp"+i, "build", NONE));
+            specs.add(new DeliveryPipelineView.ComponentSpec("Comp"+i, "build", NONE, false));
         }
         DeliveryPipelineView view = new DeliveryPipelineView("Pipeline");
         view.setComponentSpecs(specs);
@@ -431,7 +431,7 @@ public class DeliveryPipelineViewTest {
         jenkins.createFreeStyleProject("compile-Project2");
         jenkins.createFreeStyleProject("compile-Project3");
 
-        DeliveryPipelineView.RegExpSpec regExpSpec = new DeliveryPipelineView.RegExpSpec("^compile-(.*)");
+        DeliveryPipelineView.RegExpSpec regExpSpec = new DeliveryPipelineView.RegExpSpec("^compile-(.*)", false);
         List<DeliveryPipelineView.RegExpSpec> regExpSpecs = new ArrayList<DeliveryPipelineView.RegExpSpec>();
         regExpSpecs.add(regExpSpec);
 
@@ -453,7 +453,7 @@ public class DeliveryPipelineViewTest {
         FreeStyleProject build = jenkins.createFreeStyleProject("build");
         build.addProperty(new PipelineProperty("Build", "BuildStage", ""));
         List<DeliveryPipelineView.ComponentSpec> specs = new ArrayList<DeliveryPipelineView.ComponentSpec>();
-        specs.add(new DeliveryPipelineView.ComponentSpec("Comp", "build", NONE));
+        specs.add(new DeliveryPipelineView.ComponentSpec("Comp", "build", NONE, false));
         DeliveryPipelineView view = new DeliveryPipelineView("Pipeline");
         view.setComponentSpecs(specs);
         view.setSorting(NameComparator.class.getName());
@@ -621,7 +621,7 @@ public class DeliveryPipelineViewTest {
         jenkins.createFreeStyleProject("compile-Project3");
         jenkins.createFreeStyleProject("compile");
 
-        DeliveryPipelineView.RegExpSpec regExpSpec = new DeliveryPipelineView.RegExpSpec("^compile-(.*)");
+        DeliveryPipelineView.RegExpSpec regExpSpec = new DeliveryPipelineView.RegExpSpec("^compile-(.*)", false);
         List<DeliveryPipelineView.RegExpSpec> regExpSpecs = new ArrayList<DeliveryPipelineView.RegExpSpec>();
         regExpSpecs.add(regExpSpec);
 
@@ -787,7 +787,7 @@ public class DeliveryPipelineViewTest {
 
         DeliveryPipelineView view = new DeliveryPipelineView("Pipeline");
         List<DeliveryPipelineView.ComponentSpec> componentSpecs = new ArrayList<DeliveryPipelineView.ComponentSpec>();
-        componentSpecs.add(new DeliveryPipelineView.ComponentSpec("Comp", "A", NONE));
+        componentSpecs.add(new DeliveryPipelineView.ComponentSpec("Comp", "A", NONE, false));
         view.setComponentSpecs(componentSpecs);
 
         jenkins.getInstance().addView(view);
@@ -808,8 +808,8 @@ public class DeliveryPipelineViewTest {
 
         DeliveryPipelineView view = new DeliveryPipelineView("Pipeline");
         List<DeliveryPipelineView.ComponentSpec> componentSpecs = new ArrayList<DeliveryPipelineView.ComponentSpec>();
-        componentSpecs.add(new DeliveryPipelineView.ComponentSpec("Comp2", "A", NONE));
-        componentSpecs.add(new DeliveryPipelineView.ComponentSpec("Comp1", "B", NONE));
+        componentSpecs.add(new DeliveryPipelineView.ComponentSpec("Comp2", "A", NONE, false));
+        componentSpecs.add(new DeliveryPipelineView.ComponentSpec("Comp1", "B", NONE, false));
         view.setComponentSpecs(componentSpecs);
         view.setShowAggregatedPipeline(true);
         view.setSorting("this will not be found");
@@ -835,8 +835,8 @@ public class DeliveryPipelineViewTest {
 
         DeliveryPipelineView view = new DeliveryPipelineView("Pipeline");
         List<DeliveryPipelineView.ComponentSpec> componentSpecs = new ArrayList<DeliveryPipelineView.ComponentSpec>();
-        componentSpecs.add(new DeliveryPipelineView.ComponentSpec("Comp2", "A", NONE));
-        componentSpecs.add(new DeliveryPipelineView.ComponentSpec("Comp1", "B", NONE));
+        componentSpecs.add(new DeliveryPipelineView.ComponentSpec("Comp2", "A", NONE, false));
+        componentSpecs.add(new DeliveryPipelineView.ComponentSpec("Comp1", "B", NONE, false));
         view.setComponentSpecs(componentSpecs);
         view.setShowAggregatedPipeline(true);
         view.setSorting("none");
@@ -919,7 +919,7 @@ public class DeliveryPipelineViewTest {
 
         DeliveryPipelineView pipeline = new DeliveryPipelineView("Pipeline");
         List<DeliveryPipelineView.ComponentSpec> componentSpecs = new ArrayList<DeliveryPipelineView.ComponentSpec>();
-        componentSpecs.add(new DeliveryPipelineView.ComponentSpec("Spec", firstJob.getName(), NONE));
+        componentSpecs.add(new DeliveryPipelineView.ComponentSpec("Spec", firstJob.getName(), NONE, false));
         pipeline.setComponentSpecs(componentSpecs);
         jenkins.getInstance().addView(pipeline);
 

--- a/src/test/java/se/diabol/jenkins/pipeline/domain/ComponentTest.java
+++ b/src/test/java/se/diabol/jenkins/pipeline/domain/ComponentTest.java
@@ -81,7 +81,8 @@ public class ComponentTest {
         DeliveryPipelineView view = new DeliveryPipelineView("Pipeline");
         view.setPagingEnabled(true);
 
-        DeliveryPipelineView.ComponentSpec componentSpec = new DeliveryPipelineView.ComponentSpec("Pipeline","comp", null);
+        DeliveryPipelineView.ComponentSpec componentSpec = new DeliveryPipelineView.ComponentSpec("Pipeline","comp",
+                null, false);
         List<DeliveryPipelineView.ComponentSpec> componentSpecs = new ArrayList<DeliveryPipelineView.ComponentSpec>();
         componentSpecs.add(componentSpec);
         view.setComponentSpecs(componentSpecs);

--- a/src/test/java/se/diabol/jenkins/pipeline/domain/PipelineTest.java
+++ b/src/test/java/se/diabol/jenkins/pipeline/domain/PipelineTest.java
@@ -426,7 +426,8 @@ public class PipelineTest {
         assertEquals(build.getLastBuild(), BuildUtil.getFirstUpstreamBuild(build.getLastBuild(), build));
         Pipeline pipeline = Pipeline.extractPipeline("Pipeline", build);
         Component component = new Component("Component", "build", null, false, 3, pagingEnabledFalse, 1);
-        List<Pipeline> pipelines = pipeline.createPipelineLatest(1, Jenkins.getInstance(), pagingEnabledFalse, showChanges, component);
+        List<Pipeline> pipelines = pipeline.createPipelineLatest(1, Jenkins.getInstance(), pagingEnabledFalse,
+                showChanges, false, component);
         assertEquals(1, pipelines.size());
         assertEquals(1, pipelines.get(0).getTriggeredBy().size());
         assertEquals(TriggerCause.TYPE_UPSTREAM, pipelines.get(0).getTriggeredBy().get(0).getType());
@@ -699,15 +700,19 @@ public class PipelineTest {
         FreeStyleProject a = jenkins.createFreeStyleProject("A");
         Pipeline prototype = Pipeline.extractPipeline("Pipe", a);
         a.scheduleBuild(2, new Cause.UserIdCause());
-        Component component = new Component("Component",prototype.getFirstProject().getFullName(), null, false, 3, pagingEnabledFalse, 1);
-        List<Pipeline> pipelines = prototype.createPipelineLatest(5, Jenkins.getInstance(), pagingEnabledFalse, showChanges, component);
+        Component component = new Component("Component",prototype.getFirstProject().getFullName(), null, false, 3,
+                pagingEnabledFalse, 1);
+        List<Pipeline> pipelines = prototype.createPipelineLatest(5, Jenkins.getInstance(), pagingEnabledFalse,
+                showChanges, false, component);
         assertEquals(1, pipelines.size());
     }
 
-    private Pipeline createPipelineLatest(Pipeline pipeline, ItemGroup itemGroup) {
+    private Pipeline createPipelineLatest(Pipeline pipeline, ItemGroup itemGroup) throws PipelineException {
         StaplerRequest request = Mockito.mock(StaplerRequest.class);
-        Component component = new Component("Component", pipeline.getFirstProject().getFullName(), null, false, 3, pagingEnabledFalse, 1);
-        List<Pipeline> pipelines = pipeline.createPipelineLatest(1, itemGroup, pagingEnabledFalse, showChanges, component);
+        Component component = new Component("Component", pipeline.getFirstProject().getFullName(), null, false, 3,
+                pagingEnabledFalse, 1);
+        List<Pipeline> pipelines = pipeline.createPipelineLatest(1, itemGroup, pagingEnabledFalse, showChanges,
+                false, component);
         assertFalse(pipelines.isEmpty());
         return pipelines.get(0);
     }

--- a/src/test/java/se/diabol/jenkins/pipeline/domain/status/SimpleStatusTest.java
+++ b/src/test/java/se/diabol/jenkins/pipeline/domain/status/SimpleStatusTest.java
@@ -359,21 +359,25 @@ public class SimpleStatusTest {
         jenkins.waitUntilNoActivity();
 
         Component component = new Component("Component","project1", null, false, 3, pagingEnabledFalse, 1);
-        List<Pipeline> pipelines = pipeline.createPipelineLatest(2, jenkins.getInstance(), pagingEnabledFalse, showChanges, component);
+        List<Pipeline> pipelines = pipeline.createPipelineLatest(2, jenkins.getInstance(), pagingEnabledFalse,
+                showChanges, false, component);
         assertEquals(2, pipelines.size());
         assertEquals(StatusType.IDLE, pipelines.get(0).getStages().get(1).getTasks().get(0).getStatus().getType());
         assertEquals(StatusType.IDLE, pipelines.get(1).getStages().get(1).getTasks().get(0).getStatus().getType());
 
-        BuildPipelineView view = new BuildPipelineView("", "", new DownstreamProjectGridBuilder("project1"), "0", false, "");
+        BuildPipelineView view = new BuildPipelineView("", "", new DownstreamProjectGridBuilder("project1"), "0",
+                false, "");
         project1.setQuietPeriod(3);
         view.triggerManualBuild(1, "project2", "project1");
-        pipelines = pipeline.createPipelineLatest(2, jenkins.getInstance(), pagingEnabledFalse, showChanges, component);
+        pipelines = pipeline.createPipelineLatest(2, jenkins.getInstance(), pagingEnabledFalse, showChanges,
+                false, component);
         assertEquals(2, pipelines.size());
         assertEquals(StatusType.IDLE, pipelines.get(0).getStages().get(1).getTasks().get(0).getStatus().getType());
         assertEquals(StatusType.QUEUED, pipelines.get(1).getStages().get(1).getTasks().get(0).getStatus().getType());
 
         jenkins.waitUntilNoActivity();
-        pipelines = pipeline.createPipelineLatest(2, jenkins.getInstance(), pagingEnabledFalse, showChanges, component);
+        pipelines = pipeline.createPipelineLatest(2, jenkins.getInstance(), pagingEnabledFalse, showChanges,
+                false, component);
         assertEquals(2, pipelines.size());
         assertEquals(StatusType.IDLE, pipelines.get(0).getStages().get(1).getTasks().get(0).getStatus().getType());
         assertEquals(StatusType.SUCCESS, pipelines.get(1).getStages().get(1).getTasks().get(0).getStatus().getType());

--- a/src/test/java/se/diabol/jenkins/pipeline/functionaltest/GuiFunctionalIT.java
+++ b/src/test/java/se/diabol/jenkins/pipeline/functionaltest/GuiFunctionalIT.java
@@ -69,7 +69,7 @@ public class GuiFunctionalIT {
 
         DeliveryPipelineView view = new DeliveryPipelineView("Pipeline");
         List<DeliveryPipelineView.ComponentSpec> specs = new ArrayList<DeliveryPipelineView.ComponentSpec>();
-        specs.add(new DeliveryPipelineView.ComponentSpec("Component", "A", NONE));
+        specs.add(new DeliveryPipelineView.ComponentSpec("Component", "A", NONE, false));
         view.setComponentSpecs(specs);
         view.setAllowManualTriggers(true);
 
@@ -96,7 +96,7 @@ public class GuiFunctionalIT {
 
         DeliveryPipelineView view = new DeliveryPipelineView("Pipeline");
         List<DeliveryPipelineView.ComponentSpec> specs = new ArrayList<DeliveryPipelineView.ComponentSpec>();
-        specs.add(new DeliveryPipelineView.ComponentSpec("Component", "A", NONE));
+        specs.add(new DeliveryPipelineView.ComponentSpec("Component", "A", NONE, false));
         view.setComponentSpecs(specs);
         view.setAllowManualTriggers(true);
         view.setAllowRebuild(true);
@@ -129,7 +129,7 @@ public class GuiFunctionalIT {
 
         DeliveryPipelineView view = new DeliveryPipelineView("Pipeline");
         List<DeliveryPipelineView.ComponentSpec> specs = new ArrayList<DeliveryPipelineView.ComponentSpec>();
-        specs.add(new DeliveryPipelineView.ComponentSpec("Component", "A", NONE));
+        specs.add(new DeliveryPipelineView.ComponentSpec("Component", "A", NONE, false));
         view.setComponentSpecs(specs);
         view.setAllowManualTriggers(true);
         view.setAllowRebuild(true);
@@ -170,7 +170,7 @@ public class GuiFunctionalIT {
 
         DeliveryPipelineView view = new DeliveryPipelineView("Pipeline");
         List<DeliveryPipelineView.ComponentSpec> specs = new ArrayList<DeliveryPipelineView.ComponentSpec>();
-        specs.add(new DeliveryPipelineView.ComponentSpec("Component", "Start", NONE));
+        specs.add(new DeliveryPipelineView.ComponentSpec("Component", "Start", NONE, false));
         view.setComponentSpecs(specs);
         view.setAllowPipelineStart(true);
 
@@ -197,7 +197,7 @@ public class GuiFunctionalIT {
 
         DeliveryPipelineView view = new DeliveryPipelineView("Pipeline");
         List<DeliveryPipelineView.ComponentSpec> specs = new ArrayList<DeliveryPipelineView.ComponentSpec>();
-        specs.add(new DeliveryPipelineView.ComponentSpec("Component", "Start", NONE));
+        specs.add(new DeliveryPipelineView.ComponentSpec("Component", "Start", NONE, false));
         view.setComponentSpecs(specs);
         view.setAllowPipelineStart(true);
 
@@ -226,7 +226,7 @@ public class GuiFunctionalIT {
 
         DeliveryPipelineView view = new DeliveryPipelineView("Pipeline");
         List<DeliveryPipelineView.ComponentSpec> specs = new ArrayList<DeliveryPipelineView.ComponentSpec>();
-        specs.add(new DeliveryPipelineView.ComponentSpec("Component", "Start", NONE));
+        specs.add(new DeliveryPipelineView.ComponentSpec("Component", "Start", NONE, false));
         view.setComponentSpecs(specs);
         view.setAllowPipelineStart(true);
 

--- a/src/test/java/se/diabol/jenkins/pipeline/util/ProjectUtilTest.java
+++ b/src/test/java/se/diabol/jenkins/pipeline/util/ProjectUtilTest.java
@@ -28,6 +28,7 @@ import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.WithoutJenkins;
 import se.diabol.jenkins.pipeline.test.TestUtil;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -135,5 +136,19 @@ public class ProjectUtilTest {
     public void testGetAllDownstreamProjects() {
         Map<String, AbstractProject<?, ?>> result = ProjectUtil.getAllDownstreamProjects(null, null);
         assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void testGetStartUpstreamsSimple() throws Exception {
+        FreeStyleProject projectA = jenkins.createFreeStyleProject("A");
+        FreeStyleProject projectB = jenkins.createFreeStyleProject("B");
+        FreeStyleProject projectC = jenkins.createFreeStyleProject("C");
+        projectA.getPublishersList().add(new BuildTrigger(projectC.getName(), true));
+        projectB.getPublishersList().add(new BuildTrigger(projectC.getName(), true));
+
+        jenkins.getInstance().rebuildDependencyGraph();
+
+        List<AbstractProject> upstrems = ProjectUtil.getStartUpstreams(projectC);
+        assertEquals(2, upstrems.size());
     }
 }


### PR DESCRIPTION
Same functionality as in #200 

Will show upstream jobs triggered the pipeline. In this example below the Package job is configured to as the first job in the pipeline and jobs CompA and CompB have triggered the Package.
![image](https://cloud.githubusercontent.com/assets/167583/19533237/31608378-963f-11e6-8eee-94fb01a68eec.png)
