### PR TITLE
Jenkins 39614 add sort by failure

### DIFF
--- a/src/main/java/se/diabol/jenkins/pipeline/sort/FailedJobComparator.java
+++ b/src/main/java/se/diabol/jenkins/pipeline/sort/FailedJobComparator.java
@@ -43,15 +43,14 @@ public class FailedJobComparator extends ComponentComparator implements Serializ
     }
 
     private boolean hasFailedJob(Pipeline pipeline) {
-        boolean hasFailedJob = false;
         for (Stage stage : pipeline.getStages()) {
             for (Task task : stage.getTasks()) {
                 if (task.getStatus().isFailed()) {
-                    hasFailedJob = true;
+                    return true;
                 }
             }
         }
-        return hasFailedJob;
+        return false;
     }
 
     @Extension

--- a/src/main/java/se/diabol/jenkins/pipeline/sort/FailedJobComparator.java
+++ b/src/main/java/se/diabol/jenkins/pipeline/sort/FailedJobComparator.java
@@ -1,0 +1,71 @@
+/*
+This file is part of Delivery Pipeline Plugin.
+
+Delivery Pipeline Plugin is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Delivery Pipeline Plugin is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Delivery Pipeline Plugin.
+If not, see <http://www.gnu.org/licenses/>.
+*/
+package se.diabol.jenkins.pipeline.sort;
+
+import hudson.Extension;
+import se.diabol.jenkins.pipeline.domain.Component;
+import se.diabol.jenkins.pipeline.domain.Pipeline;
+import se.diabol.jenkins.pipeline.domain.Stage;
+import se.diabol.jenkins.pipeline.domain.task.Task;
+
+import java.io.Serializable;
+
+public class FailedJobComparator extends ComponentComparator implements Serializable {
+
+    @Override
+    public int compare(Component o1, Component o2) {
+        if ((hasFailedJob(firstPipeline(o1)) && (!hasFailedJob(firstPipeline(o2))))) {
+            return -1;
+        } else if ((hasFailedJob(firstPipeline(o2)) && (!hasFailedJob(firstPipeline(o1))))) {
+            return 1;
+        } else {
+            return new LatestActivityComparator().compare(o1, o2);
+        }
+    }
+
+    private Pipeline firstPipeline(Component o1) {
+        return o1.getPipelines().get(0);
+    }
+
+    private boolean hasFailedJob(Pipeline pipeline) {
+        boolean hasFailedJob = false;
+        for (Stage stage : pipeline.getStages()) {
+            for (Task task : stage.getTasks()) {
+                if (task.getStatus().isFailed()) {
+                    hasFailedJob = true;
+                }
+            }
+        }
+        return hasFailedJob;
+    }
+
+    @Extension
+    public static class DescriptorImpl extends ComponentComparatorDescriptor {
+        @Override
+        public String getDisplayName() {
+            return "Sorting by failed pipelines, then by last activity";
+        }
+
+        @Override
+        public ComponentComparator createInstance() {
+            return new FailedJobComparator();
+        }
+    }
+
+
+}

--- a/src/test/java/se/diabol/jenkins/pipeline/DeliveryPipelineViewTest.java
+++ b/src/test/java/se/diabol/jenkins/pipeline/DeliveryPipelineViewTest.java
@@ -26,6 +26,7 @@ import static org.junit.Assert.fail;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+
 import hudson.model.TopLevelItem;
 import hudson.model.AbstractBuild;
 import hudson.model.Api;
@@ -320,7 +321,7 @@ public class DeliveryPipelineViewTest {
         assertTrue(view.contains(sonar));
         assertTrue(view.contains(packaging));
 
-        Collection<TopLevelItem> items =  view.getItems();
+        Collection<TopLevelItem> items = view.getItems();
         assertEquals(3, items.size());
 
     }
@@ -348,7 +349,7 @@ public class DeliveryPipelineViewTest {
         MockFolder folder = jenkins.createFolder("folder");
         FreeStyleProject build = folder.createProject(FreeStyleProject.class, "build");
         FreeStyleProject sonar = folder.createProject(FreeStyleProject.class, "sonar");
-        FreeStyleProject packaging = folder.createProject(FreeStyleProject.class,"packaging");
+        FreeStyleProject packaging = folder.createProject(FreeStyleProject.class, "packaging");
 
 
         build.getPublishersList().add(new BuildTrigger("sonar", false));
@@ -367,7 +368,7 @@ public class DeliveryPipelineViewTest {
         assertTrue(view.contains(sonar));
         assertTrue(view.contains(packaging));
 
-        Collection<TopLevelItem> items =  view.getItems();
+        Collection<TopLevelItem> items = view.getItems();
         assertEquals(3, items.size());
 
     }
@@ -414,8 +415,8 @@ public class DeliveryPipelineViewTest {
     public void allJobsAreReturnedWhenMaxNotSet() throws Exception {
         jenkins.createFreeStyleProject("build");
         List<DeliveryPipelineView.ComponentSpec> specs = new ArrayList<DeliveryPipelineView.ComponentSpec>();
-        for(int i = 0;i<100;i++) {
-            specs.add(new DeliveryPipelineView.ComponentSpec("Comp"+i, "build", NONE));
+        for (int i = 0; i < 100; i++) {
+            specs.add(new DeliveryPipelineView.ComponentSpec("Comp" + i, "build", NONE));
         }
         DeliveryPipelineView view = new DeliveryPipelineView("Pipeline");
         view.setComponentSpecs(specs);
@@ -531,10 +532,10 @@ public class DeliveryPipelineViewTest {
     @SuppressWarnings("all")
     public void testDoCheckName() {
         DeliveryPipelineView.ComponentSpec.DescriptorImpl d = new DeliveryPipelineView.ComponentSpec.DescriptorImpl();
-        assertEquals(FormValidation.Kind.ERROR,  d.doCheckName(null).kind);
-        assertEquals(FormValidation.Kind.ERROR,  d.doCheckName("").kind);
-        assertEquals(FormValidation.Kind.ERROR,  d.doCheckName(" ").kind);
-        assertEquals(FormValidation.Kind.OK,  d.doCheckName("Component").kind);
+        assertEquals(FormValidation.Kind.ERROR, d.doCheckName(null).kind);
+        assertEquals(FormValidation.Kind.ERROR, d.doCheckName("").kind);
+        assertEquals(FormValidation.Kind.ERROR, d.doCheckName(" ").kind);
+        assertEquals(FormValidation.Kind.OK, d.doCheckName("Component").kind);
     }
 
     @Test
@@ -687,7 +688,7 @@ public class DeliveryPipelineViewTest {
 
         DeliveryPipelineView view = new DeliveryPipelineView("Delivery Pipeline");
         jenkins.getInstance().addView(view);
-        
+
         testDoCreateItem("testDoCreateItemAsTheDefaultViewFromTheViewUrl", "view/Delivery%20Pipeline/");
 
         jenkins.getInstance().setPrimaryView(view);
@@ -700,7 +701,7 @@ public class DeliveryPipelineViewTest {
         form.getInputByName("name").setValueAttribute(projectName);
         form.getRadioButtonsByName("mode").get(0).setChecked(true);
         jenkins.submit(form);
-        
+
         assertTrue(jenkins.jenkins.getJobNames().contains(projectName));
     }
 

--- a/src/test/java/se/diabol/jenkins/pipeline/PipelineVersionContributorTest.java
+++ b/src/test/java/se/diabol/jenkins/pipeline/PipelineVersionContributorTest.java
@@ -224,7 +224,7 @@ public class PipelineVersionContributorTest {
         FreeStyleProject firstProject = jenkins.createFreeStyleProject("firstProject");
         FreeStyleProject secondProject = jenkins.createFreeStyleProject("secondProject");
         firstProject.getPublishersList().add(
-            new BuildPipelineTrigger("secondProject", Arrays.<AbstractBuildParameters>asList(new BooleanParameters(Arrays.asList(new BooleanParameterConfig("test", true))))));
+                new BuildPipelineTrigger("secondProject", Arrays.<AbstractBuildParameters>asList(new BooleanParameters(Arrays.asList(new BooleanParameterConfig("test", true))))));
         firstProject.save();
 
         firstProject.getBuildWrappersList().add(new PipelineVersionContributor(true, "1.0.0.${BUILD_NUMBER}"));

--- a/src/test/java/se/diabol/jenkins/pipeline/sort/FailedJobComparatorTest.java
+++ b/src/test/java/se/diabol/jenkins/pipeline/sort/FailedJobComparatorTest.java
@@ -45,9 +45,8 @@ public class FailedJobComparatorTest {
         Component successfulComponent = createComponent(status(SUCCESS, new DateTime().minusDays(1)));
 
         List<Component> list = new ArrayList<Component>();
-        list.add(failedComponent);
         list.add(successfulComponent);
-        Collections.shuffle(list);
+        list.add(failedComponent);
         Collections.sort(list, new FailedJobComparator.DescriptorImpl().createInstance());
         assertEquals(failedComponent, list.get(0));
         assertEquals(successfulComponent, list.get(1));
@@ -60,10 +59,9 @@ public class FailedJobComparatorTest {
         Component failedComponent = createComponent(status(FAILED, new DateTime().minusDays(1)));
         Component successfulComponent = createComponent(status(SUCCESS, new DateTime().minusDays(1)));
         List<Component> list = new ArrayList<Component>();
-        list.add(failedComponent);
         list.add(successfulComponent);
+        list.add(failedComponent);
         list.add(failedComponentRunLongAgo);
-        Collections.shuffle(list);
         Collections.sort(list, new FailedJobComparator.DescriptorImpl().createInstance());
         assertEquals(failedComponent, list.get(0));
         assertEquals(failedComponentRunLongAgo, list.get(1));

--- a/src/test/java/se/diabol/jenkins/pipeline/sort/FailedJobComparatorTest.java
+++ b/src/test/java/se/diabol/jenkins/pipeline/sort/FailedJobComparatorTest.java
@@ -71,7 +71,7 @@ public class FailedJobComparatorTest {
     }
 
     private Status status(StatusType statusType, DateTime lastRunAt) {
-        return new SimpleStatus(statusType, lastRunAt.getMillis(),10, false, Lists.<PromotionStatus>newArrayList());
+        return new SimpleStatus(statusType, lastRunAt.getMillis(), 10, false, Lists.<PromotionStatus>newArrayList());
     }
 
 }

--- a/src/test/java/se/diabol/jenkins/pipeline/sort/FailedJobComparatorTest.java
+++ b/src/test/java/se/diabol/jenkins/pipeline/sort/FailedJobComparatorTest.java
@@ -1,0 +1,77 @@
+/*
+This file is part of Delivery Pipeline Plugin.
+
+Delivery Pipeline Plugin is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Delivery Pipeline Plugin is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Delivery Pipeline Plugin.
+If not, see <http://www.gnu.org/licenses/>.
+*/
+package se.diabol.jenkins.pipeline.sort;
+
+import com.google.common.collect.Lists;
+import org.joda.time.DateTime;
+import org.junit.Test;
+import se.diabol.jenkins.pipeline.domain.Component;
+import se.diabol.jenkins.pipeline.domain.status.SimpleStatus;
+import se.diabol.jenkins.pipeline.domain.status.Status;
+import se.diabol.jenkins.pipeline.domain.status.StatusType;
+import se.diabol.jenkins.pipeline.domain.status.promotion.PromotionStatus;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static se.diabol.jenkins.pipeline.domain.status.StatusType.FAILED;
+import static se.diabol.jenkins.pipeline.domain.status.StatusType.SUCCESS;
+import static se.diabol.jenkins.pipeline.test.PipelineUtil.createComponent;
+
+public class FailedJobComparatorTest {
+
+
+    @Test
+    public void shouldSortFailedBeforeSuccessful() {
+
+        Component failedComponent = createComponent(status(FAILED, new DateTime().minusDays(1)));
+        Component successfulComponent = createComponent(status(SUCCESS, new DateTime().minusDays(1)));
+
+        List<Component> list = new ArrayList<Component>();
+        list.add(failedComponent);
+        list.add(successfulComponent);
+        Collections.shuffle(list);
+        Collections.sort(list, new FailedJobComparator.DescriptorImpl().createInstance());
+        assertEquals(failedComponent, list.get(0));
+        assertEquals(successfulComponent, list.get(1));
+    }
+
+    @Test
+    public void shouldSortRecentlyRunFirstIfSameStatus() {
+
+        Component failedComponentRunLongAgo = createComponent(status(FAILED, new DateTime().minusDays(10)));
+        Component failedComponent = createComponent(status(FAILED, new DateTime().minusDays(1)));
+        Component successfulComponent = createComponent(status(SUCCESS, new DateTime().minusDays(1)));
+        List<Component> list = new ArrayList<Component>();
+        list.add(failedComponent);
+        list.add(successfulComponent);
+        list.add(failedComponentRunLongAgo);
+        Collections.shuffle(list);
+        Collections.sort(list, new FailedJobComparator.DescriptorImpl().createInstance());
+        assertEquals(failedComponent, list.get(0));
+        assertEquals(failedComponentRunLongAgo, list.get(1));
+        assertEquals(successfulComponent, list.get(2));
+    }
+
+    private Status status(StatusType statusType, DateTime lastRunAt) {
+        return new SimpleStatus(statusType, lastRunAt.getMillis(),10, false, Lists.<PromotionStatus>newArrayList());
+    }
+
+}

--- a/src/test/java/se/diabol/jenkins/pipeline/sort/LatestActivityComparatorTest.java
+++ b/src/test/java/se/diabol/jenkins/pipeline/sort/LatestActivityComparatorTest.java
@@ -17,61 +17,31 @@ If not, see <http://www.gnu.org/licenses/>.
 */
 package se.diabol.jenkins.pipeline.sort;
 
+import org.joda.time.DateTime;
 import org.junit.Test;
 import se.diabol.jenkins.pipeline.domain.Component;
-import se.diabol.jenkins.pipeline.domain.Pipeline;
-import se.diabol.jenkins.pipeline.domain.Stage;
-import se.diabol.jenkins.pipeline.domain.status.StatusFactory;
-import se.diabol.jenkins.pipeline.domain.status.promotion.PromotionStatus;
-import se.diabol.jenkins.pipeline.domain.task.Task;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static se.diabol.jenkins.pipeline.domain.status.StatusType.SUCCESS;
+import static se.diabol.jenkins.pipeline.test.PipelineUtil.createComponent;
+import static se.diabol.jenkins.pipeline.test.PipelineUtil.status;
 
 public class LatestActivityComparatorTest {
 
-    private final static boolean pagingEnabledFalse = false;
 
     @Test
-    public void testCompare() {
-        Task taskA = new Task(null, "task", "Build", StatusFactory.success(0, 20, false,
-                Collections.<PromotionStatus>emptyList()), null, null, null, true, "");
-
-        List<Task> tasksA = new ArrayList<Task>();
-        tasksA.add(taskA);
-        Stage stageA = new Stage("Build", tasksA);
-        List<Stage> stagesA = new ArrayList<Stage>();
-        stagesA.add(stageA);
-        Pipeline pipelineA = new Pipeline("Pipeline A", null, null, "1.0.0.1", null, null, null, stagesA, false);
-        List<Pipeline> pipelinesA = new ArrayList<Pipeline>();
-        pipelinesA.add(pipelineA);
-
-        Task taskB = new Task(null, "task", "Build", StatusFactory.success(10, 20, false,
-                Collections.<PromotionStatus>emptyList()), null, null, null, true, "");
-
-        List<Task> tasksB = new ArrayList<Task>();
-        tasksB.add(taskB);
-        Stage stageB = new Stage("Build", tasksB);
-        List<Stage> stagesB = new ArrayList<Stage>();
-        stagesB.add(stageB);
-        Pipeline pipelineB = new Pipeline("Pipeline B", null, null, "1.0.0.1", null, null, null, stagesB, false);
-        List<Pipeline> pipelinesB = new ArrayList<Pipeline>();
-        pipelinesB.add(pipelineB);
-
-
-        Component componentB = new Component("B", "B", "job/A", false, 3, pagingEnabledFalse,1);
-        Component componentA = new Component("A", "A", "job/B", false, 3, pagingEnabledFalse, 1);
-        componentB.setPipelines(pipelinesB);
-        componentA.setPipelines(pipelinesA);
+    public void shouldSortRecentlyRunnedPipelinesFirst() {
+        Component componentRunLongAgo = createComponent(status(SUCCESS, new DateTime().minusDays(2)));
+        Component componentRunRecently = createComponent(status(SUCCESS, new DateTime().minusDays(1)));
         List<Component> list = new ArrayList<Component>();
-        list.add(componentB);
-        list.add(componentA);
+        list.add(componentRunRecently);
+        list.add(componentRunLongAgo);
         Collections.sort(list, new LatestActivityComparator.DescriptorImpl().createInstance());
-        assertEquals(componentB, list.get(0));
-        assertEquals(componentA, list.get(1));
+        assertEquals(componentRunRecently, list.get(0));
+        assertEquals(componentRunLongAgo, list.get(1));
     }
-
 }

--- a/src/test/java/se/diabol/jenkins/pipeline/test/PipelineUtil.java
+++ b/src/test/java/se/diabol/jenkins/pipeline/test/PipelineUtil.java
@@ -1,3 +1,20 @@
+/*
+This file is part of Delivery Pipeline Plugin.
+
+Delivery Pipeline Plugin is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Delivery Pipeline Plugin is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Delivery Pipeline Plugin.
+If not, see <http://www.gnu.org/licenses/>.
+*/
 package se.diabol.jenkins.pipeline.test;
 
 import com.google.common.collect.Lists;

--- a/src/test/java/se/diabol/jenkins/pipeline/test/PipelineUtil.java
+++ b/src/test/java/se/diabol/jenkins/pipeline/test/PipelineUtil.java
@@ -1,0 +1,39 @@
+package se.diabol.jenkins.pipeline.test;
+
+import com.google.common.collect.Lists;
+import org.joda.time.DateTime;
+import se.diabol.jenkins.pipeline.domain.Component;
+import se.diabol.jenkins.pipeline.domain.Pipeline;
+import se.diabol.jenkins.pipeline.domain.Stage;
+import se.diabol.jenkins.pipeline.domain.status.SimpleStatus;
+import se.diabol.jenkins.pipeline.domain.status.Status;
+import se.diabol.jenkins.pipeline.domain.status.StatusType;
+import se.diabol.jenkins.pipeline.domain.status.promotion.PromotionStatus;
+import se.diabol.jenkins.pipeline.domain.task.Task;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class PipelineUtil {
+
+    public static Component createComponent(Status status) {
+        Task task = new Task(null, "task", "Build", status, null, null, null, true, "");
+
+        List<Task> tasks = new ArrayList<Task>();
+        tasks.add(task);
+        Stage stage = new Stage("Build", tasks);
+        List<Stage> stages = new ArrayList<Stage>();
+        stages.add(stage);
+        Pipeline pipeline = new Pipeline("Pipeline B", null, null, "1.0.0.1", null, null, null, stages, false);
+        List<Pipeline> pipelines = new ArrayList<Pipeline>();
+        pipelines.add(pipeline);
+        Component component = new Component("B", "B", "job/A", false, 3, false, 1);
+        component.setPipelines(pipelines);
+        return component;
+    }
+
+    public static Status status(StatusType statusType, DateTime lastRunedAt) {
+        return new SimpleStatus(statusType, lastRunedAt.getMillis(), 10, false, Lists.<PromotionStatus>newArrayList());
+    }
+
+}


### PR DESCRIPTION

Added comparator that sorts pipelines with status failed first, and then by how recently they where run.