### PR TITLE
JENKINS-40763 Return a non-expanded string template if the token-macro plugin fails with a MacroEvaluationException

### DIFF
--- a/src/main/java/se/diabol/jenkins/pipeline/token/TokenUtils.java
+++ b/src/main/java/se/diabol/jenkins/pipeline/token/TokenUtils.java
@@ -48,7 +48,8 @@ public final class TokenUtils {
                 return template.replaceAll("\\$\\{.*?\\}", "...");
             }
         } catch (MacroEvaluationException e) {
-            LOG.log(Level.WARNING, e.getMessage());
+            LOG.log(Level.WARNING, "Failed to evaluate token using token-macro plugin", e);
+            return template;
         } catch (Exception e) {
             LOG.log(Level.WARNING, TokenUtils.MESSAGE + e.getMessage());
         }

--- a/src/test/java/se/diabol/jenkins/pipeline/token/TokenUtilsTest.java
+++ b/src/test/java/se/diabol/jenkins/pipeline/token/TokenUtilsTest.java
@@ -56,7 +56,7 @@ public class TokenUtilsTest {
         jenkins.setQuietPeriod(0);
 
         FreeStyleBuild build = jenkins.buildAndAssertSuccess(a);
-        assertEquals("", TokenUtils.decodedTemplate(build, "${TEST_NESTEDX}"));
+        assertEquals("${TEST_NESTEDX}", TokenUtils.decodedTemplate(build, "${TEST_NESTEDX}"));
     }
 
     @Test


### PR DESCRIPTION
* Provided a more fine grained error message with stacktrace
* A non-expanded string will make it more obvious that expansion failed
* Will correctly display delivery pipeline task names which has no expandable variables in the delivery pipeline view instead of defaulting to job name