### PR TITLE
Dashboard view plugin as required dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -496,7 +496,6 @@
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>dashboard-view</artifactId>
             <version>2.9.2</version>
-            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>


### PR DESCRIPTION
* Since it is directly used in the DeliveryPipelineViewPortlet class