### PR TITLE
Improve performance when tab/window is not active

### DIFF
--- a/src/main/webapp/pipe.js
+++ b/src/main/webapp/pipe.js
@@ -1,6 +1,15 @@
 function pipelineUtils() {
     var self = this;
     this.updatePipelines = function(divNames, errorDiv, view, fullscreen, page, component, showChanges, aggregatedChangesGroupingPattern, timeout, pipelineid, jsplumb) {
+
+        // Don't refresh pipelines if the tab/window is not active
+        if (document.hidden) {
+            setTimeout(function () {
+                self.updatePipelines(divNames, errorDiv, view, fullscreen, page, component, showChanges, aggregatedChangesGroupingPattern, timeout, pipelineid, jsplumb);
+            }, timeout);
+            return;
+        }
+
         Q.ajax({
             url: rootURL + '/' + view.viewUrl + 'api/json' + '?page=' + page + '&component=' + component + '&fullscreen=' + fullscreen,
             dataType: 'json',


### PR DESCRIPTION
We've seen CPU overhead to be significant with multiple complex pipelines tabs open at once and active jobs running. This ensures that we're not reloading pipelines if a tab/window is not active.