### PR TITLE
[JENKINS-46249] Fixed 404 Error while configuring Delivery Pipeline view

### DIFF
--- a/src/main/java/se/diabol/jenkins/pipeline/DeliveryPipelineView.java
+++ b/src/main/java/se/diabol/jenkins/pipeline/DeliveryPipelineView.java
@@ -650,6 +650,14 @@ public class DeliveryPipelineView extends View implements PipelineView {
             return options;
         }
 
+        public ListBoxModel doFillThemeItems(@AncestorInPath ItemGroup<?> context) {
+            ListBoxModel options = new ListBoxModel();
+            options.add("Default", "default");
+            options.add("Contrast", "contrast");
+            options.add("Overview", "overview");
+            return options;
+        }
+
         public FormValidation doCheckUpdateInterval(@QueryParameter String value) {
             int valueAsInt;
             try {

--- a/src/main/java/se/diabol/jenkins/workflow/WorkflowPipelineView.java
+++ b/src/main/java/se/diabol/jenkins/workflow/WorkflowPipelineView.java
@@ -327,6 +327,14 @@ public class WorkflowPipelineView extends View implements PipelineView {
             return options;
         }
 
+        public ListBoxModel doFillThemeItems(@AncestorInPath ItemGroup<?> context) {
+            ListBoxModel options = new ListBoxModel();
+            options.add("Default", "default");
+            options.add("Contrast", "contrast");
+            options.add("Overview", "overview");
+            return options;
+        }
+
         public FormValidation doCheckUpdateInterval(@QueryParameter String value) {
             int valueAsInt;
             try {

--- a/src/main/resources/se/diabol/jenkins/pipeline/DeliveryPipelineView/configure-entries.jelly
+++ b/src/main/resources/se/diabol/jenkins/pipeline/DeliveryPipelineView/configure-entries.jelly
@@ -99,12 +99,8 @@
             <f:checkbox/>
         </f:entry>
 
-        <f:entry name="theme" title="Theme" field="theme">
-            <select name="theme" class="setting-input  select">
-                <option value="default" selected="${instance.getTheme().equals('default')? 'true':null}">Default</option>
-                <option value="contrast" selected="${instance.getTheme().equals('contrast')? 'true':null}">Contrast</option>
-                <option value="overview" selected="${instance.getTheme().equals('overview')? 'true':null}">Overview</option>
-            </select>
+        <f:entry title="Theme" field="theme">
+            <f:select />
         </f:entry>
 
     </f:section>

--- a/src/main/resources/se/diabol/jenkins/workflow/WorkflowPipelineView/configure-entries.jelly
+++ b/src/main/resources/se/diabol/jenkins/workflow/WorkflowPipelineView/configure-entries.jelly
@@ -22,12 +22,8 @@
         <f:entry title="Show commit messages" field="showChanges">
             <f:checkbox/>
         </f:entry>
-        <f:entry name="theme" title="Theme" field="theme">
-            <select name="theme" class="setting-input  select">
-                <option value="default" selected="${instance.getTheme().equals('default')? 'true':null}">Default</option>
-                <option value="contrast" selected="${instance.getTheme().equals('contrast')? 'true':null}">Contrast</option>
-                <option value="overview" selected="${instance.getTheme().equals('overview')? 'true':null}">Overview</option>
-            </select>
+        <f:entry title="Theme" field="theme">
+            <f:select />
         </f:entry>
     </f:section>
 


### PR DESCRIPTION
As there is change in Select box scripts of Jenkins core, when used direct select tag instead of the Jelly form f:select it is showing 404 error below to the select box while configuring view
![image-2017-08-16-23-20-46-923](https://user-images.githubusercontent.com/8586903/29442714-f8b66fc4-83f0-11e7-9d0d-ba6f6f035942.png)

In this PR changed to f:select and filling options using the Descriptor method.