### PR TITLE
JENKINS-47408 Link directly to the corresponding pipeline run for Jenkins pipelines

### DIFF
--- a/src/main/java/se/diabol/jenkins/workflow/WorkflowApi.java
+++ b/src/main/java/se/diabol/jenkins/workflow/WorkflowApi.java
@@ -18,12 +18,9 @@ If not, see <http://www.gnu.org/licenses/>.
 package se.diabol.jenkins.workflow;
 
 import com.cloudbees.workflow.rest.external.RunExt;
-import hudson.model.ItemGroup;
-import hudson.model.TopLevelItem;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import se.diabol.jenkins.pipeline.domain.PipelineException;
-import se.diabol.jenkins.pipeline.util.ProjectUtil;
 import se.diabol.jenkins.workflow.api.Run;
 
 import java.util.ArrayList;
@@ -34,11 +31,7 @@ public class WorkflowApi {
     public WorkflowApi() {
     }
 
-    public List<Run> getRunsFor(String name, ItemGroup<? extends TopLevelItem> ownerItemGroup)
-            throws PipelineException {
-        WorkflowJob job;
-        job = ProjectUtil.getWorkflowJob(name, ownerItemGroup);
-
+    public List<Run> getRunsFor(WorkflowJob job) {
         List<Run> runs = new ArrayList<>();
         for (WorkflowRun run : job.getBuilds()) {
             runs.add(new Run(RunExt.create(run)));
@@ -46,9 +39,12 @@ public class WorkflowApi {
         return runs;
     }
 
-    public Run lastFinishedRunFor(String job, ItemGroup<? extends TopLevelItem> ownerItemGroup)
-            throws PipelineException {
-        for (Run run : getRunsFor(job, ownerItemGroup)) {
+    public Run lastFinishedRunFor(WorkflowJob job) throws PipelineException {
+        return lastFinishedRun(getRunsFor(job));
+    }
+
+    private Run lastFinishedRun(List<Run> runs) {
+        for (Run run : runs) {
             if (!"IN_PROGRESS".equals(run.status) && !"PAUSED_PENDING_INPUT".equals(run.status)) {
                 return run;
             }

--- a/src/main/java/se/diabol/jenkins/workflow/WorkflowPipelineView.java
+++ b/src/main/java/se/diabol/jenkins/workflow/WorkflowPipelineView.java
@@ -285,7 +285,7 @@ public class WorkflowPipelineView extends View implements PipelineView {
     }
 
     private Pipeline resolvePipeline(WorkflowJob job, WorkflowRun build) throws PipelineException {
-        Pipeline pipeline = Pipeline.resolve(job, build, getOwnerItemGroup());
+        Pipeline pipeline = Pipeline.resolve(job, build);
         if (showChanges) {
             pipeline.setChanges(getChangelog(build));
         }

--- a/src/main/java/se/diabol/jenkins/workflow/model/Pipeline.java
+++ b/src/main/java/se/diabol/jenkins/workflow/model/Pipeline.java
@@ -18,8 +18,6 @@ If not, see <http://www.gnu.org/licenses/>.
 package se.diabol.jenkins.workflow.model;
 
 import com.cloudbees.workflow.flownode.FlowNodeUtil;
-import hudson.model.ItemGroup;
-import hudson.model.TopLevelItem;
 import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
@@ -43,6 +41,7 @@ public class Pipeline extends AbstractItem {
     private String version;
 
     private List<TriggerCause> triggeredBy;
+
     private Set<UserInfo> contributors;
 
     private String timestamp;
@@ -112,15 +111,13 @@ public class Pipeline extends AbstractItem {
         return triggeredBy;
     }
 
-    public static Pipeline resolve(WorkflowJob project,
-                                   WorkflowRun build,
-                                   ItemGroup<? extends TopLevelItem> ownerItemGroup) throws PipelineException {
+    public static Pipeline resolve(WorkflowJob project, WorkflowRun build) throws PipelineException {
         String pipelineTimestamp = PipelineUtils.formatTimestamp(build.getTimeInMillis());
 
         List<FlowNode> stageNodes = FlowNodeUtil.getStageNodes(build.getExecution());
         return new Pipeline(project.getName(),
                 build.getDisplayName(),
-                Stage.extractStages(build, stageNodes, ownerItemGroup),
+                Stage.extractStages(build, stageNodes),
                 Change.getChanges(build.getChangeSets()),
                 TriggerCause.getTriggeredBy(project, build),
                 pipelineTimestamp);

--- a/src/main/java/se/diabol/jenkins/workflow/model/Stage.java
+++ b/src/main/java/se/diabol/jenkins/workflow/model/Stage.java
@@ -122,10 +122,8 @@ public class Stage extends AbstractItem {
         return downstreamStageIds;
     }
 
-    static List<Stage> extractStages(WorkflowRun build,
-                                     List<FlowNode> stageNodes,
-                                     ItemGroup<? extends TopLevelItem> ownerItemGroup) throws PipelineException {
-        List<Stage> result = resolveStageNodes(build, stageNodes, ownerItemGroup);
+    static List<Stage> extractStages(WorkflowRun build, List<FlowNode> stageNodes) throws PipelineException {
+        List<Stage> result = resolveStageNodes(build, stageNodes);
         for (int i = 0; i < result.size(); i++) {
             Stage stage = result.get(i);
             if (i + 1 < result.size()) {
@@ -138,13 +136,11 @@ public class Stage extends AbstractItem {
         return result;
     }
 
-    private static List<Stage> resolveStageNodes(WorkflowRun build,
-                                                 List<FlowNode> stageNodes,
-                                                 ItemGroup<? extends TopLevelItem> ownerItemGroup)
+    private static List<Stage> resolveStageNodes(WorkflowRun build, List<FlowNode> stageNodes)
             throws PipelineException {
         List<Stage> result = new ArrayList<>();
         for (FlowNode stageNode : stageNodes) {
-            List<Task> tasks = Task.resolve(build, stageNode, ownerItemGroup);
+            List<Task> tasks = Task.resolve(build, stageNode);
             result.add(new Stage(stageNode.getDisplayName(), tasks));
         }
         return result;

--- a/src/main/java/se/diabol/jenkins/workflow/model/Task.java
+++ b/src/main/java/se/diabol/jenkins/workflow/model/Task.java
@@ -144,7 +144,9 @@ public class Task extends AbstractItem {
     }
 
     private static String taskLinkFor(WorkflowRun build) {
-        return "job/" + Name.of(build).replace("/", "/job/");
+        String taskLink = "job/" + Name.of(build).replace("/", "/job/");
+        taskLink += "/" + build.getNumber() + "/";
+        return taskLink;
     }
 
     static boolean taskNodesDefinedInStage(List<FlowNode> taskNodes) {

--- a/src/main/java/se/diabol/jenkins/workflow/util/Name.java
+++ b/src/main/java/se/diabol/jenkins/workflow/util/Name.java
@@ -17,9 +17,6 @@ If not, see <http://www.gnu.org/licenses/>.
 */
 package se.diabol.jenkins.workflow.util;
 
-import com.cloudbees.hudson.plugins.folder.Folder;
-import hudson.model.AbstractItem;
-import jenkins.branch.MultiBranchProject;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 
 public final class Name {
@@ -28,25 +25,7 @@ public final class Name {
         if (build == null) {
             return null;
         }
-        if (parentIsFolder(build)) {
-            return qualifiedNameOf(build);
-        } else if (parentIsMultiBranch(build)) {
-            return ((AbstractItem) ((MultiBranchProject)
-                    build.getParent().getParent())).getName() + "/" + build.getParent().getName();
-        } else {
-            return build.getParent().getName();
-        }
-    }
-
-    protected static String qualifiedNameOf(WorkflowRun build) {
         return build.getParent().getFullName();
     }
 
-    private static boolean parentIsMultiBranch(WorkflowRun build) {
-        return build.getParent().getParent() instanceof MultiBranchProject;
-    }
-
-    private static boolean parentIsFolder(WorkflowRun build) {
-        return build.getParent().getParent() instanceof Folder;
-    }
 }

--- a/src/test/java/se/diabol/jenkins/pipeline/workflow/PipelineTest.java
+++ b/src/test/java/se/diabol/jenkins/pipeline/workflow/PipelineTest.java
@@ -46,7 +46,7 @@ public class PipelineTest {
 
         WorkflowPipelineView view = new WorkflowPipelineView(pipelineName);
 
-        Pipeline pipeline = Pipeline.resolve(pipelineProject, build, view.getOwnerItemGroup());
+        Pipeline pipeline = Pipeline.resolve(pipelineProject, build);
         assertNotNull(pipeline);
         assertThat(pipeline.getName(), is(pipelineName));
         assertThat(pipeline.getStages().size(), is(2));
@@ -72,7 +72,7 @@ public class PipelineTest {
 
         WorkflowPipelineView view = new WorkflowPipelineView(pipelineName);
 
-        Pipeline pipeline = Pipeline.resolve(pipelineProject, build, view.getOwnerItemGroup());
+        Pipeline pipeline = Pipeline.resolve(pipelineProject, build);
         assertNotNull(pipeline);
         assertThat(pipeline.getStages().size(), is(2));
         assertThat(pipeline.getStages().get(0).getName(), is("Build"));

--- a/src/test/java/se/diabol/jenkins/workflow/WorkflowApiTest.java
+++ b/src/test/java/se/diabol/jenkins/workflow/WorkflowApiTest.java
@@ -21,15 +21,15 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import hudson.model.ItemGroup;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Mockito;
+import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import se.diabol.jenkins.pipeline.domain.PipelineException;
 import se.diabol.jenkins.workflow.api.Run;
@@ -43,9 +43,12 @@ public class WorkflowApiTest {
 
     private WorkflowApi workflowApi = mock(WorkflowApi.class);
 
+    @Mock
+    private ItemGroup itemGroup;
+
     @Before
     public void setup() throws IOException, PipelineException {
-        when(workflowApi.lastFinishedRunFor(anyString(), any(ItemGroup.class))).thenCallRealMethod();
+        when(workflowApi.lastFinishedRunFor(any(WorkflowJob.class))).thenCallRealMethod();
     }
 
     @Test
@@ -54,10 +57,10 @@ public class WorkflowApiTest {
         Run pausedRun = new Run(null, null, null, "PAUSED_PENDING_INPUT", null, null, null, null);
         Run finishedRun = new Run(null, "5", "#5", "SUCCESS", null, null, null, null);
         Run earlierFinishedRun = new Run(null, "4", "#4", "SUCCESS", null, null, null, null);
-        when(workflowApi.getRunsFor(anyString(), any(ItemGroup.class)))
+        when(workflowApi.getRunsFor(any(WorkflowJob.class)))
                 .thenReturn(Arrays.asList(inProgressRun, pausedRun, finishedRun, earlierFinishedRun));
 
-        Run run = workflowApi.lastFinishedRunFor("Test Workflow", Mockito.mock(ItemGroup.class));
+        Run run = workflowApi.lastFinishedRunFor(new WorkflowJob(itemGroup, "Test Workflow"));
         assertThat(run.id, is(finishedRun.id));
         assertThat(run.name, is(finishedRun.name));
         assertThat(run.status, is(finishedRun.status));
@@ -67,9 +70,9 @@ public class WorkflowApiTest {
     public void shouldNotGetLastFinishedRunForJobIfOnlyInProgressOrPausedJobsExist() throws PipelineException {
         Run inProgressRun = new Run(null, null, null, "IN_PROGRESS", null, null, null, null);
         Run pausedRun = new Run(null, null, null, "PAUSED_PENDING_INPUT", null, null, null, null);
-        when(workflowApi.getRunsFor(anyString(), any(ItemGroup.class)))
+        when(workflowApi.getRunsFor(any(WorkflowJob.class)))
                 .thenReturn(Arrays.asList(inProgressRun, pausedRun));
 
-        assertThat(workflowApi.lastFinishedRunFor("Test Workflow", Mockito.mock(ItemGroup.class)), nullValue());
+        assertThat(workflowApi.lastFinishedRunFor(new WorkflowJob(itemGroup, "Test Workflow")), nullValue());
     }
 }

--- a/src/test/java/se/diabol/jenkins/workflow/util/NameTest.java
+++ b/src/test/java/se/diabol/jenkins/workflow/util/NameTest.java
@@ -63,7 +63,7 @@ public class NameTest {
         WorkflowJob workflowJob = new WorkflowJob(multiBranch, "wf");
         WorkflowRun workflowRun = new WorkflowRun(workflowJob);
 
-        assertThat(Name.of(workflowRun), is("mb/wf"));
+        assertThat(Name.of(workflowRun), is("folder/mb/wf"));
     }
     
     @Test


### PR DESCRIPTION
* Improved how full job names are resolved
* Fixes broken links that occurs under some circumstances when using nested structures
* Refactored WorkflowApi to use WorkflowJob objects instead of strings for simplified usage