### PR TITLE
test scope removed from dependency artifactId:workflow-basic-steps

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -682,7 +682,6 @@
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-basic-steps</artifactId>
             <version>2.6</version>
-            <scope>test</scope>
         </dependency>
 
     </dependencies>


### PR DESCRIPTION
There was a plugin installation error when we run the project. Test scope parameter removed from artifactId:workflow-basic-step dependency in pom.xml.