### PR TITLE
JENKINS-38062 Remove unsafe ParametersAction usage warnings

### DIFF
--- a/src/main/java/se/diabol/jenkins/pipeline/EnvVersionTokenMacro.java
+++ b/src/main/java/se/diabol/jenkins/pipeline/EnvVersionTokenMacro.java
@@ -21,7 +21,6 @@ import hudson.Extension;
 import hudson.model.AbstractBuild;
 import hudson.model.TaskListener;
 import org.jenkinsci.plugins.tokenmacro.DataBoundTokenMacro;
-import org.jenkinsci.plugins.tokenmacro.MacroEvaluationException;
 
 import java.io.IOException;
 import java.util.Map;
@@ -37,7 +36,7 @@ public class EnvVersionTokenMacro extends DataBoundTokenMacro {
 
     @Override
     public String evaluate(AbstractBuild<?, ?> context, TaskListener listener, String macroName)
-            throws MacroEvaluationException, IOException, InterruptedException {
+            throws IOException, InterruptedException {
         Map<String, String> env = context.getEnvironment(listener);
         if (env.containsKey(NAME)) {
             if (stripSnapshot) {

--- a/src/main/java/se/diabol/jenkins/pipeline/PipelineVersionContributor.java
+++ b/src/main/java/se/diabol/jenkins/pipeline/PipelineVersionContributor.java
@@ -23,9 +23,6 @@ import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
 import hudson.model.BuildListener;
 import hudson.model.CauseAction;
-import hudson.model.ParameterValue;
-import hudson.model.ParametersAction;
-import hudson.model.StringParameterValue;
 import hudson.tasks.BuildWrapper;
 import hudson.tasks.BuildWrapperDescriptor;
 
@@ -34,8 +31,6 @@ import org.jenkinsci.plugins.tokenmacro.TokenMacro;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -46,7 +41,7 @@ public class PipelineVersionContributor extends BuildWrapper {
     public static final String VERSION_PARAMETER = "PIPELINE_VERSION";
 
     private final String versionTemplate;
-    private boolean updateDisplayName = false;
+    private boolean updateDisplayName;
 
     private static final Logger LOG = Logger.getLogger(PipelineVersionContributor.class.getName());
 
@@ -65,8 +60,8 @@ public class PipelineVersionContributor extends BuildWrapper {
     }
 
     @Override
-    public Environment setUp(AbstractBuild build, Launcher launcher, BuildListener listener) throws IOException,
-            InterruptedException {
+    public Environment setUp(AbstractBuild build, Launcher launcher, BuildListener listener)
+            throws IOException, InterruptedException {
         try {
 
             String version = TokenMacro.expandAll(build, listener, getVersionTemplate());
@@ -83,8 +78,7 @@ public class PipelineVersionContributor extends BuildWrapper {
         }
         return new Environment() {
             @Override
-            public boolean tearDown(AbstractBuild build, BuildListener listener)
-                    throws IOException, InterruptedException {
+            public boolean tearDown(AbstractBuild build, BuildListener listener) {
                 return true;
             }
         };
@@ -106,19 +100,6 @@ public class PipelineVersionContributor extends BuildWrapper {
         } else {
             build.replaceAction(action);
         }
-        build.replaceAction(getVersionParameterAction(build, version));
-    }
-
-    // Backwards compatibility for 0.9.9 and older
-    private static ParametersAction getVersionParameterAction(AbstractBuild build, String version) {
-        ParameterValue value = new StringParameterValue(PipelineVersionContributor.VERSION_PARAMETER, version);
-        ParametersAction action = build.getAction(ParametersAction.class);
-        if (action != null) {
-            List<ParameterValue> parameters = new ArrayList<>(action.getParameters());
-            parameters.add(value);
-            return new ParametersAction(parameters);
-        }
-        return new ParametersAction(value);
     }
 
     static class PipelineVersionAction extends CauseAction {

--- a/src/main/java/se/diabol/jenkins/pipeline/PipelineVersionTokenMacro.java
+++ b/src/main/java/se/diabol/jenkins/pipeline/PipelineVersionTokenMacro.java
@@ -23,15 +23,13 @@ import hudson.model.TaskListener;
 import org.jenkinsci.plugins.tokenmacro.DataBoundTokenMacro;
 import org.jenkinsci.plugins.tokenmacro.MacroEvaluationException;
 
-import java.io.IOException;
-
 @Extension
 @SuppressWarnings("UnusedDeclaration")
 public class PipelineVersionTokenMacro extends DataBoundTokenMacro {
 
     @Override
-    public String evaluate(AbstractBuild<?, ?> context, TaskListener listener, String macroName) throws
-            MacroEvaluationException, IOException, InterruptedException {
+    public String evaluate(AbstractBuild<?, ?> context, TaskListener listener, String macroName)
+            throws MacroEvaluationException {
         String version = PipelineVersionContributor.getVersion(context);
         if (version == null) {
             throw new MacroEvaluationException("Could not find " + PipelineVersionContributor.VERSION_PARAMETER


### PR DESCRIPTION
* Affects usage of pipeline version generation in DeliveryPipelineView based views
* Remove usage of ParametersAction - essentially there for backwards compatability with Delivery Pipeline plugin 0.9.9 and older which with this code change is no longer supported