### PR TITLE
Update checkstyle tool version, remove invalid rule, fix rule violation.

### DIFF
--- a/checkstyle-rules.xml
+++ b/checkstyle-rules.xml
@@ -56,9 +56,7 @@
             <property name="tokens" value="LITERAL_TRY, LITERAL_FINALLY, LITERAL_IF, LITERAL_ELSE, LITERAL_SWITCH"/>
         </module>
         <module name="NeedBraces"/>
-        <module name="LeftCurly">
-            <property name="maxLineLength" value="100"/>
-        </module>
+	<module name="LeftCurly"/>
         <module name="RightCurly"/>
         <module name="RightCurly">
             <property name="option" value="alone"/>

--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,7 @@
                         <dependency>
                             <groupId>com.puppycrawl.tools</groupId>
                             <artifactId>checkstyle</artifactId>
-                            <version>6.11.1</version>
+                            <version>8.18</version>
                         </dependency>
                     </dependencies>
                 </plugin>

--- a/src/main/java/se/diabol/jenkins/pipeline/domain/status/promotion/PromotionStatus.java
+++ b/src/main/java/se/diabol/jenkins/pipeline/domain/status/promotion/PromotionStatus.java
@@ -17,7 +17,6 @@ If not, see <http://www.gnu.org/licenses/>.
 */
 package se.diabol.jenkins.pipeline.domain.status.promotion;
 
-
 import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.export.ExportedBean;
 import se.diabol.jenkins.core.AbstractItem;


### PR DESCRIPTION
Update Checkstyle dependency to avoid pulling in external DTDs. Remove a rule that's in violation of the baked-in DTD, and fix a whitespace rule violation that offends the update version.

This fix can alternatively be rebased onto the pending jdk11 branch.