### PR TITLE
JENKINS-58332 Fix broken promotion duration display

### DIFF
--- a/src/main/webapp/pipe.js
+++ b/src/main/webapp/pipe.js
@@ -458,7 +458,7 @@ function generatePromotionsInfo(data, task) {
         if (promo.user !== 'anonymous') {
             html.push('<span class="promo-user">' + promo.user + '</span>');
         }
-        html.push('<span class="promo-time">' + formatDuration(promo.time) + '</span><br/>');
+        html.push('<span class="promo-time">' + formatDuration(promo.duration) + '</span><br/>');
         if (promo.params.length > 0) {
             html.push('<br/>');
         }


### PR DESCRIPTION
The duration of the promotion was displayed as NaN because an undefined property was referenced.