### PR TITLE
JENKINS-61056

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ env:
   global:
     - JENKINSCI_USERNAME=diabol_jenkins
     - secure: "R3Wz/PgUYQqelwxXu+mMkHHzpLaFTxWmj6m+fOxnlJ85njJXOf/4jrMwMMLlvUM3DgZ+dJp8nANNxUPkOBIBLfbSNWGZTsLEJkGu+hEtBKCZhHLLXfIYhVc8tVFgEvfQo4QP+LXk63COfaIlE45cD8NIqFzebbMeN9K/MCOAIuw="
+jdk:
+  - openjdk8
 notifications:
   slack:
     secure: phVNsiDfu5nDM7okqhGgX1Qhh3Sawqy5X3p5bgDarh9RX82V2OAebyiiKiw6aNGyDCoD0ElMHmz7tbdBODsR3muWyoQ5EJBsDgNv1NM9dhkdeIQ/182bF7EBFciPW5SYjl0+dOkIeMn9DHdg8i0RVxwjy6GjJX2r/6oUmYxExQk=

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ notifications:
     secure: phVNsiDfu5nDM7okqhGgX1Qhh3Sawqy5X3p5bgDarh9RX82V2OAebyiiKiw6aNGyDCoD0ElMHmz7tbdBODsR3muWyoQ5EJBsDgNv1NM9dhkdeIQ/182bF7EBFciPW5SYjl0+dOkIeMn9DHdg8i0RVxwjy6GjJX2r/6oUmYxExQk=
 before_install:
   - "export DISPLAY=:99.0"
-  - "sh -e /etc/init.d/xvfb start"
   - "sed 's/localhost.localdomain localhost/localhost localhost.localdomain/' /etc/hosts > /tmp/etchostsfile && cat /tmp/etchostsfile | sudo tee /etc/hosts"
   - echo "MAVEN_OPTS='-Xmx2g -XX:MaxPermSize=1024m'" > ~/.mavenrc
   - wget -N http://chromedriver.storage.googleapis.com/2.35/chromedriver_linux64.zip -P ~/
@@ -20,6 +19,8 @@ before_install:
 script:
   - "if [[ -z $TRAVIS_TAG ]]; then mvn --batch-mode -Dwebdriver.chrome.driver=/usr/local/share/chromedriver install; fi"
   - "if [[ -n $TRAVIS_TAG ]]; then ./release.sh master $TRAVIS_TAG; fi"
+services:
+  - xvfb
 cache:
   directories:
   - $HOME/.m2

--- a/checkstyle-rules.xml
+++ b/checkstyle-rules.xml
@@ -31,6 +31,12 @@
 
     <module name="NewlineAtEndOfFile"/>
 
+    <module name="LineLength">
+        <property name="max" value="120"/>
+        <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://"/>
+        <property name="fileExtensions" value="java"/>
+    </module>
+
     <module name="TreeWalker">
         <module name="OuterTypeFilename"/>
         <module name="IllegalTokenText">
@@ -43,10 +49,6 @@
             <property name="allowEscapesForControlCharacters" value="true"/>
             <property name="allowByTailComment" value="true"/>
             <property name="allowNonPrintableEscapes" value="true"/>
-        </module>
-        <module name="LineLength">
-            <property name="max" value="120"/>
-            <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://"/>
         </module>
         <module name="AvoidStarImport"/>
         <module name="OneTopLevelClass"/>
@@ -155,6 +157,7 @@
         <module name="OverloadMethodsDeclarationOrder"/>
         <module name="VariableDeclarationUsageDistance"/>
         <module name="CustomImportOrder">
+            <property name="separateLineBetweenGroups" value="false"/>
             <property name="sortImportsInGroupAlphabetically" value="true"/>
             <property name="customImportOrderRules"
                       value="STATIC###SPECIAL_IMPORTS###THIRD_PARTY_PACKAGE###STANDARD_JAVA_PACKAGE"/>

--- a/pom.xml
+++ b/pom.xml
@@ -607,7 +607,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>token-macro</artifactId>
-            <version>1.12.1</version>
+            <version>2.0</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -500,7 +500,11 @@
             <version>1.3.2</version>
             <scope>provided</scope>
         </dependency>
-
+        <dependency>
+            <groupId>joda-time</groupId>
+            <artifactId>joda-time</artifactId>
+            <version>2.10.5</version>
+        </dependency>
         <!-- Test Dependencies -->
         <dependency>
             <groupId>commons-beanutils</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>se.diabol.jenkins.pipeline</groupId>
     <artifactId>delivery-pipeline-plugin</artifactId>
-    <version>1.4.2-SNAPSHOT</version>
+    <version>1.4.2</version>
     <packaging>hpi</packaging>
     <name>Delivery Pipeline Plugin</name>
     <url>https://wiki.jenkins-ci.org/display/JENKINS/Delivery+Pipeline+Plugin</url>
@@ -66,7 +66,7 @@
         <connection>scm:git:https://github.com/Diabol/delivery-pipeline-plugin.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/Diabol/delivery-pipeline-plugin.git</developerConnection>
         <url>https://github.com/Diabol/delivery-pipeline-plugin/</url>
-        <tag>HEAD</tag>
+        <tag>delivery-pipeline-plugin-1.4.2</tag>
     </scm>
 
     <developers>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>se.diabol.jenkins.pipeline</groupId>
     <artifactId>delivery-pipeline-plugin</artifactId>
-    <version>1.4.2</version>
+    <version>1.4.3-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <name>Delivery Pipeline Plugin</name>
     <url>https://wiki.jenkins-ci.org/display/JENKINS/Delivery+Pipeline+Plugin</url>
@@ -66,7 +66,7 @@
         <connection>scm:git:https://github.com/Diabol/delivery-pipeline-plugin.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/Diabol/delivery-pipeline-plugin.git</developerConnection>
         <url>https://github.com/Diabol/delivery-pipeline-plugin/</url>
-        <tag>delivery-pipeline-plugin-1.4.2</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <developers>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>se.diabol.jenkins.pipeline</groupId>
     <artifactId>delivery-pipeline-plugin</artifactId>
-    <version>1.4.1-SNAPSHOT</version>
+    <version>1.4.1</version>
     <packaging>hpi</packaging>
     <name>Delivery Pipeline Plugin</name>
     <url>https://wiki.jenkins-ci.org/display/JENKINS/Delivery+Pipeline+Plugin</url>
@@ -66,7 +66,7 @@
         <connection>scm:git:https://github.com/Diabol/delivery-pipeline-plugin.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/Diabol/delivery-pipeline-plugin.git</developerConnection>
         <url>https://github.com/Diabol/delivery-pipeline-plugin/</url>
-        <tag>HEAD</tag>
+        <tag>delivery-pipeline-plugin-1.4.1</tag>
     </scm>
 
     <developers>

--- a/pom.xml
+++ b/pom.xml
@@ -112,12 +112,12 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-checkstyle-plugin</artifactId>
-                    <version>2.17</version>
+                    <version>3.1.1</version>
                     <dependencies>
                         <dependency>
                             <groupId>com.puppycrawl.tools</groupId>
                             <artifactId>checkstyle</artifactId>
-                            <version>8.18</version>
+                            <version>8.29</version>
                         </dependency>
                     </dependencies>
                 </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>se.diabol.jenkins.pipeline</groupId>
     <artifactId>delivery-pipeline-plugin</artifactId>
-    <version>1.4.1</version>
+    <version>1.4.2-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <name>Delivery Pipeline Plugin</name>
     <url>https://wiki.jenkins-ci.org/display/JENKINS/Delivery+Pipeline+Plugin</url>
@@ -66,7 +66,7 @@
         <connection>scm:git:https://github.com/Diabol/delivery-pipeline-plugin.git</connection>
         <developerConnection>scm:git:ssh://git@github.com/Diabol/delivery-pipeline-plugin.git</developerConnection>
         <url>https://github.com/Diabol/delivery-pipeline-plugin/</url>
-        <tag>delivery-pipeline-plugin-1.4.1</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <developers>

--- a/src/main/java/se/diabol/jenkins/pipeline/CauseResolver.java
+++ b/src/main/java/se/diabol/jenkins/pipeline/CauseResolver.java
@@ -19,12 +19,10 @@ package se.diabol.jenkins.pipeline;
 
 import hudson.ExtensionPoint;
 import hudson.model.Cause;
-
 import se.diabol.jenkins.pipeline.domain.TriggerCause;
 import se.diabol.jenkins.pipeline.util.JenkinsUtil;
 
 import java.util.List;
-
 import javax.annotation.CheckForNull;
 
 public abstract class CauseResolver implements ExtensionPoint {

--- a/src/main/java/se/diabol/jenkins/pipeline/PipelineProperty.java
+++ b/src/main/java/se/diabol/jenkins/pipeline/PipelineProperty.java
@@ -24,14 +24,11 @@ import hudson.model.Job;
 import hudson.model.JobProperty;
 import hudson.model.JobPropertyDescriptor;
 import hudson.util.FormValidation;
-
 import net.sf.json.JSONObject;
-
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.export.Exported;
-
 import se.diabol.jenkins.pipeline.util.JenkinsUtil;
 
 import java.util.HashSet;

--- a/src/main/java/se/diabol/jenkins/pipeline/PipelineVersionContributor.java
+++ b/src/main/java/se/diabol/jenkins/pipeline/PipelineVersionContributor.java
@@ -25,7 +25,6 @@ import hudson.model.BuildListener;
 import hudson.model.CauseAction;
 import hudson.tasks.BuildWrapper;
 import hudson.tasks.BuildWrapperDescriptor;
-
 import org.jenkinsci.plugins.tokenmacro.MacroEvaluationException;
 import org.jenkinsci.plugins.tokenmacro.TokenMacro;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -33,7 +32,6 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import java.io.IOException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
 import javax.annotation.CheckForNull;
 
 public class PipelineVersionContributor extends BuildWrapper {

--- a/src/main/java/se/diabol/jenkins/pipeline/domain/Component.java
+++ b/src/main/java/se/diabol/jenkins/pipeline/domain/Component.java
@@ -20,11 +20,9 @@ package se.diabol.jenkins.pipeline.domain;
 import static com.google.common.base.MoreObjects.toStringHelper;
 
 import com.google.common.collect.ImmutableList;
-
 import org.kohsuke.stapler.Stapler;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.export.Exported;
-
 import org.kohsuke.stapler.export.ExportedBean;
 import se.diabol.jenkins.core.AbstractItem;
 import se.diabol.jenkins.core.GenericComponent;

--- a/src/main/java/se/diabol/jenkins/pipeline/domain/results/Result.java
+++ b/src/main/java/se/diabol/jenkins/pipeline/domain/results/Result.java
@@ -19,7 +19,6 @@ package se.diabol.jenkins.pipeline.domain.results;
 
 import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.export.ExportedBean;
-
 import se.diabol.jenkins.core.AbstractItem;
 
 @ExportedBean(defaultVisibility = AbstractItem.VISIBILITY)

--- a/src/main/java/se/diabol/jenkins/pipeline/resolver/GitCauseResolver.java
+++ b/src/main/java/se/diabol/jenkins/pipeline/resolver/GitCauseResolver.java
@@ -20,7 +20,6 @@ package se.diabol.jenkins.pipeline.resolver;
 import hudson.Extension;
 import hudson.model.Cause;
 import hudson.plugins.git.GitStatus;
-
 import se.diabol.jenkins.pipeline.CauseResolver;
 import se.diabol.jenkins.pipeline.domain.TriggerCause;
 

--- a/src/main/java/se/diabol/jenkins/pipeline/token/TokenUtils.java
+++ b/src/main/java/se/diabol/jenkins/pipeline/token/TokenUtils.java
@@ -17,6 +17,7 @@ If not, see <http://www.gnu.org/licenses/>.
 */
 package se.diabol.jenkins.pipeline.token;
 
+import hudson.FilePath;
 import hudson.model.AbstractBuild;
 import hudson.model.TaskListener;
 import org.jenkinsci.plugins.tokenmacro.MacroEvaluationException;
@@ -25,6 +26,9 @@ import org.jenkinsci.plugins.tokenmacro.TokenMacro;
 import java.io.IOException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
+
+import java.util.List;
 
 public final class TokenUtils {
 
@@ -57,6 +61,13 @@ public final class TokenUtils {
         if (build == null) {
             return hideVariable(template);
         } else {
+            // If workspace is not available, build a phony one and expand anyway.
+            // This avoids broken variable expansion on builds with transient workspaces
+            FilePath workspace = build.getWorkspace();
+            if (workspace == null) {
+               workspace = new FilePath((hudson.remoting.VirtualChannel) null, "") ;
+               return TokenMacro.expandAll(build, workspace, TaskListener.NULL, template, true, (List<TokenMacro>) null ) ;
+            }
             return TokenMacro.expandAll(build, TaskListener.NULL, template);
         }
     }

--- a/src/main/java/se/diabol/jenkins/workflow/WorkflowPipelineView.java
+++ b/src/main/java/se/diabol/jenkins/workflow/WorkflowPipelineView.java
@@ -40,6 +40,7 @@ import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.jenkinsci.plugins.workflow.support.steps.input.InputAction;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
@@ -110,6 +111,7 @@ public class WorkflowPipelineView extends View implements PipelineView {
         return noOfColumns;
     }
 
+    @DataBoundSetter
     public void setNoOfColumns(int noOfColumns) {
         this.noOfColumns = noOfColumns;
     }
@@ -124,6 +126,7 @@ public class WorkflowPipelineView extends View implements PipelineView {
         return updateInterval;
     }
 
+    @DataBoundSetter
     public void setUpdateInterval(int updateInterval) {
         this.updateInterval = updateInterval;
     }
@@ -132,6 +135,7 @@ public class WorkflowPipelineView extends View implements PipelineView {
         return noOfPipelines;
     }
 
+    @DataBoundSetter
     public void setNoOfPipelines(int noOfPipelines) {
         this.noOfPipelines = noOfPipelines;
     }
@@ -140,6 +144,7 @@ public class WorkflowPipelineView extends View implements PipelineView {
         return sorting;
     }
 
+    @DataBoundSetter
     public void setSorting(String sorting) {
         this.sorting = sorting;
     }
@@ -150,6 +155,7 @@ public class WorkflowPipelineView extends View implements PipelineView {
         return allowPipelineStart;
     }
 
+    @DataBoundSetter
     public void setAllowPipelineStart(boolean allowPipelineStart) {
         this.allowPipelineStart = allowPipelineStart;
     }
@@ -160,6 +166,7 @@ public class WorkflowPipelineView extends View implements PipelineView {
         return allowAbort;
     }
 
+    @DataBoundSetter
     public void setAllowAbort(boolean allowAbort) {
         this.allowAbort = allowAbort;
     }
@@ -168,6 +175,7 @@ public class WorkflowPipelineView extends View implements PipelineView {
         return showChanges;
     }
 
+    @DataBoundSetter
     public void setShowChanges(boolean showChanges) {
         this.showChanges = showChanges;
     }
@@ -177,6 +185,7 @@ public class WorkflowPipelineView extends View implements PipelineView {
         return showAbsoluteDateTime;
     }
 
+    @DataBoundSetter
     public void setShowAbsoluteDateTime(boolean showAbsoluteDateTime) {
         this.showAbsoluteDateTime = showAbsoluteDateTime;
     }
@@ -185,6 +194,7 @@ public class WorkflowPipelineView extends View implements PipelineView {
         return maxNumberOfVisiblePipelines;
     }
 
+    @DataBoundSetter
     public void setMaxNumberOfVisiblePipelines(int maxNumberOfVisiblePipelines) {
         this.maxNumberOfVisiblePipelines = maxNumberOfVisiblePipelines;
     }
@@ -204,6 +214,7 @@ public class WorkflowPipelineView extends View implements PipelineView {
         return componentSpecs;
     }
 
+    @DataBoundSetter
     public void setComponentSpecs(List<ComponentSpec> componentSpecs) {
         this.componentSpecs = componentSpecs;
     }
@@ -219,6 +230,7 @@ public class WorkflowPipelineView extends View implements PipelineView {
         return linkToConsoleLog;
     }
 
+    @DataBoundSetter
     public void setLinkToConsoleLog(boolean linkToConsoleLog) {
         this.linkToConsoleLog = linkToConsoleLog;
     }
@@ -232,6 +244,7 @@ public class WorkflowPipelineView extends View implements PipelineView {
         return super.description;
     }
 
+    @DataBoundSetter
     public void setDescription(String description) {
         super.description = description;
         this.description = description;


### PR DESCRIPTION
* (patch) token-macro => 2.0 and workaround for missing workspace

I need to depend on token-macro >= 2.0 in order to have  the expandAll() method which accepts workspace as parameter and so work around the exception thrown by token-macro.

The workaround was very helpful for us because all our builds on ecs ( containers ) nodes had variable expansion broken.