### PR TITLE
Configure Maven Fork Test parameters

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -249,7 +249,7 @@
                         <exclude>**/*IT.java</exclude>
                     </excludes>
                     <argLine>-Xmx2048m</argLine>
-                    <forkCount>0</forkCount>
+                    <forkCount>1.5C</forkCount>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION

Maven will run all tests in a single forked VM by default. This can be problematic if there are a lot of tests or some very memory-hungry ones. We can fork more test VM by setting `<fork>1.5C</fork>`.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
