### PR TITLE
Replace clock.png with clock.svg

### DIFF
--- a/src/main/webapp/pipe.js
+++ b/src/main/webapp/pipe.js
@@ -324,7 +324,7 @@ function addPipelineHeader(html, component, data, c, resURL) {
         } else {
             html.push('&nbsp;<a id="startpipeline-' + c  +'" class="task-icon-link" href="#" onclick="triggerBuild(\'' + component.firstJobUrl + '\', \'' + data.name + '\')">');
         }
-        html.push('<img class="icon-clock icon-md" title="Build now" src="' + resURL + '/images/24x24/clock.png">');
+        html.push('<img class="icon-clock icon-md" title="Build now" src="' + resURL + '/images/svgs/clock.svg">');
         html.push('</a>');
     }
     html.push('</h1>');


### PR DESCRIPTION
The icon for `Build now` is broken.

<img width="488" alt="Screenshot 2023-12-12 at 4 31 36 PM" src="https://github.com/Diabol/delivery-pipeline-plugin/assets/6958022/98a01fad-c079-4101-aad6-454fdd61fcf9">

I believe it is because Jenkins core has moved from pngs to svgs.  More info [here](https://community.jenkins.io/t/jenkins-installation-has-no-ui-images/2957/7). This PR is the easiest fix for the same. Unfortunately I'm unable to build the plugin locally since it throws lot of maven plugin errors.

But, I was able to verify the fix by changing the local cache in Jenkins home. 